### PR TITLE
Fix Debug utility class (CR-2: Maintainability improvement)

### DIFF
--- a/JavaSource/org/unitime/commons/Debug.java
+++ b/JavaSource/org/unitime/commons/Debug.java
@@ -36,6 +36,11 @@ import org.apache.commons.logging.LogFactory;
  * @author Tomas Muller
  */
 public class Debug {
+
+	private Debug() {
+		throw new UnsupportedOperationException("Utility class");
+	}
+	
     // Number format for logging (allocated memory)
     private static NumberFormat sNumberFormat =
             new DecimalFormat("###,#00.00", new DecimalFormatSymbols(Locale.US));


### PR DESCRIPTION
This PR fixes a maintainability issue in Debug.java.

Problem:
- Debug class was a utility class but had an implicit public constructor
- This allowed unintended instantiation

Solution:
- Added a private constructor
- Prevents object creation
- Follows Java utility class best practices

Impact:
- Improves code design
- Prevents misuse of utility class