### PR TITLE
Fix duplicated string literals and refactoring high cognitive complexity (CR-2 )

### DIFF
--- a/JavaSource/org/unitime/commons/web/WebTable.java
+++ b/JavaSource/org/unitime/commons/web/WebTable.java
@@ -15,8 +15,8 @@
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
-*/
+ *
+ */
 package org.unitime.commons.web;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ import org.unitime.timetable.security.SessionContext;
 public class WebTable {
 
     /** down arrow */
-	protected static String IMG_DEC = "images/listdir_top_to_bot.gif";
+    protected static String IMG_DEC = "images/listdir_top_to_bot.gif";
 
     /** up arrow */
     protected static String IMG_ASC = "images/listdir_bot_to_top.gif";
@@ -73,24 +73,24 @@ public class WebTable {
 
     /** row style - actually it is cell style */
     protected String iRowStyle = null;
-    
+
     /** suppress row highlighting */
     protected boolean suppressRowHighlight = false;
-    
+
     /** column filter -- hashatable <column key, Boolean> -- true if the column is filtered */
     private Hashtable iColumnFilter = null;
 
     /** column filter -- column keys */
     private String[]  iColumnFilterKeys = null;
-    
+
     protected boolean iBlankWhenSame = false;
-    
+
     protected WebTableTweakStyle iWebTableTweakStyle = null;
     protected WebTableCellStyle iWebTableCellStyle = null;
 
     private static final String ALIGN_RIGHT = "right";
     private static final String COLSPAN = " colspan=";
-    
+
     /** creates a WebTable instance */
     public WebTable(int columns, String name, String[] headers, String[] align, boolean[] asc) {
         this(columns, name, null, headers, align, asc);
@@ -113,140 +113,140 @@ public class WebTable {
         iColumnFilter = filter;
         iColumnFilterKeys = keys;
     }
-    
+
     public void setWebTableTweakStyle(WebTableTweakStyle style) {
-    	iWebTableTweakStyle = style;
+        iWebTableTweakStyle = style;
     }
-    
+
     public void setCellStyle(WebTableCellStyle style) {
-    	iWebTableCellStyle = style;
+        iWebTableCellStyle = style;
     }
-    
+
     public String getStyle(WebTableLine line, WebTableLine next, int order) {
-    	String style = (iRowStyle==null?"":iRowStyle+";")+(iWebTableTweakStyle==null?"":iWebTableTweakStyle.getStyleHtml(line, next, order));
-    	return (style==null || style.length()==0? "" : "style=\""+style+"\"");
+        String style = (iRowStyle==null?"":iRowStyle+";")+(iWebTableTweakStyle==null?"":iWebTableTweakStyle.getStyleHtml(line, next, order));
+        return (style==null || style.length()==0? "" : "style=\""+style+"\"");
     }
-    
+
     public String getCellStyle(WebTableLine line, int column, String defaultStyle) {
-    	String style = (iWebTableCellStyle == null ? null : iWebTableCellStyle.getCellStyleHtml(line, column));
-    	return (style == null ? defaultStyle : "style=\""+style+"\"");
+        String style = (iWebTableCellStyle == null ? null : iWebTableCellStyle.getCellStyleHtml(line, column));
+        return (style == null ? defaultStyle : "style=\""+style+"\"");
     }
-    
+
     /** sets row (cell) style */
     public void setRowStyle(String style) {
         iRowStyle = (iRowStyle == null ? "" : iRowStyle + ";") + style;
     }
-    
+
     /** sets row highlight suppression */
     public void setSuppressRowHighlight(boolean suppress) {
         suppressRowHighlight = suppress;
     }
-    
+
     /** enable horizontal lines */
     public void enableHR() {
         setRowStyle("border-bottom: rgb(81,81,81) 1px solid");
     }
-    
+
     /** enable horizontal lines */
     public void enableHR(String colorCode) {
         setRowStyle("border-bottom: 1px dashed " + colorCode);
     }
-    
+
     /** add line to the table */
     public WebTableLine addLine(String[] line, Comparable[] orderby) {
-        WebTableLine wtline = new WebTableLine(null, line, orderby); 
+        WebTableLine wtline = new WebTableLine(null, line, orderby);
         iLines.addElement(wtline);
         return wtline;
     }
-    
+
     /** add line to the table */
     public WebTableLine addLine(String onClick, String[] line, Comparable[] orderby, String uniqueId) {
-        WebTableLine wtline = new WebTableLine(onClick, line, orderby, uniqueId); 
+        WebTableLine wtline = new WebTableLine(onClick, line, orderby, uniqueId);
         iLines.addElement(wtline);
         return wtline;
     }
 
-	/** add line to the table */
-	public WebTableLine addLine(String onClick, String[] line, Comparable[] orderby) {
-		return addLine(onClick, line, orderby,null);
-	}
-   
-    public WebTableLine replaceLine(int index, String onClick, String[] line, Comparable[] orderby){
-    	return replaceLine(index, onClick, line, null, null);
+    /** add line to the table */
+    public WebTableLine addLine(String onClick, String[] line, Comparable[] orderby) {
+        return addLine(onClick, line, orderby,null);
     }
-    
-	public WebTableLine replaceLine(int index, String onClick, String[] line, Comparable[] orderby, String uniqueId){
-		if (index >= 0 && index < iLines.size()){
-			iLines.remove(index);
-            WebTableLine wtline = new WebTableLine(onClick, line, orderby, uniqueId);
-			iLines.add(index, wtline);
-            return wtline;
-		}
-        return null;
-	}
 
-	/* 
-	 * Return the index of the line containing uniqueId
-	 * Returns -1 if not found
-	 */
-	public int indexOfLine (String uniqueId) {
-		int indx = 0;
-		boolean found = false;
-		for (indx = 0; indx < iLines.size() && !found; indx++) {
-			WebTableLine wtLine = (WebTableLine) iLines.get(indx);
-			if (wtLine.getUniqueId().equals(uniqueId))
-				found = true; 
-		}
-		if (found) {
-			return --indx;
-		} else {
-			return -1;
-		}
-	}
-	
-	/* 
-	 * Return  line containing uniqueId
-	 * Returns null if not found
-	 */
-	public WebTableLine findLine (String uniqueId) {
-		int indx = indexOfLine(uniqueId);
-		if (indx >= 0)
-			return (WebTableLine) iLines.get(indx);
-		else
-			return null;
-	}
-	
-	/* 
-	 * Return next uniqueId after line containing uniqueId
-	 * Returns null if not found
-	 */
-	public String nextUniqueId (String uniqueId) {
-		int indx = indexOfLine(uniqueId);
-		if (indx < 0 || indx >= iLines.size() - 1) {
-			return null;
-		} else {
-			return ((WebTableLine) iLines.get(indx + 1)).getUniqueId();
-		}
-	}
-	
-	/* 
-	 * Return previous uniqueId to line containing uniqueId
-	 * Returns null if not found
-	 */
-	public String previousUniqueId (String uniqueId) {
-		int indx = indexOfLine(uniqueId);
-		if (indx <= 0 ) {
-			return null;
-		} else {
-			return ((WebTableLine) iLines.get(indx - 1)).getUniqueId();
-		}
-	}
+    public WebTableLine replaceLine(int index, String onClick, String[] line, Comparable[] orderby){
+        return replaceLine(index, onClick, line, null, null);
+    }
+
+    public WebTableLine replaceLine(int index, String onClick, String[] line, Comparable[] orderby, String uniqueId){
+        if (index >= 0 && index < iLines.size()){
+            iLines.remove(index);
+            WebTableLine wtline = new WebTableLine(onClick, line, orderby, uniqueId);
+            iLines.add(index, wtline);
+            return wtline;
+        }
+        return null;
+    }
+
+    /*
+     * Return the index of the line containing uniqueId
+     * Returns -1 if not found
+     */
+    public int indexOfLine (String uniqueId) {
+        int indx = 0;
+        boolean found = false;
+        for (indx = 0; indx < iLines.size() && !found; indx++) {
+            WebTableLine wtLine = (WebTableLine) iLines.get(indx);
+            if (wtLine.getUniqueId().equals(uniqueId))
+                found = true;
+        }
+        if (found) {
+            return --indx;
+        } else {
+            return -1;
+        }
+    }
+
+    /*
+     * Return  line containing uniqueId
+     * Returns null if not found
+     */
+    public WebTableLine findLine (String uniqueId) {
+        int indx = indexOfLine(uniqueId);
+        if (indx >= 0)
+            return (WebTableLine) iLines.get(indx);
+        else
+            return null;
+    }
+
+    /*
+     * Return next uniqueId after line containing uniqueId
+     * Returns null if not found
+     */
+    public String nextUniqueId (String uniqueId) {
+        int indx = indexOfLine(uniqueId);
+        if (indx < 0 || indx >= iLines.size() - 1) {
+            return null;
+        } else {
+            return ((WebTableLine) iLines.get(indx + 1)).getUniqueId();
+        }
+    }
+
+    /*
+     * Return previous uniqueId to line containing uniqueId
+     * Returns null if not found
+     */
+    public String previousUniqueId (String uniqueId) {
+        int indx = indexOfLine(uniqueId);
+        if (indx <= 0 ) {
+            return null;
+        } else {
+            return ((WebTableLine) iLines.get(indx - 1)).getUniqueId();
+        }
+    }
 
     /** returns table's HTML code */
     public String printTable() {
         return printTable(0);
     }
-    
+
     /** is column filtered? */
     protected boolean isFiltered(int col) {
         if (iColumnFilter == null) {
@@ -258,7 +258,7 @@ public class WebTable {
                 ? ((Boolean) iColumnFilter.get(name)).booleanValue()
                 : false);
     }
-    
+
     public int getNrFilteredColumns() {
         if (iColumnFilter==null) return 0;
         int ret = 0;
@@ -267,153 +267,50 @@ public class WebTable {
         }
         return ret;
     }
-    
+
     protected static String align(String alignment, boolean rtl) {
-    	if (rtl && "left".equalsIgnoreCase(alignment)) return ALIGN_RIGHT;
-    	return alignment;
+        if (rtl && "left".equalsIgnoreCase(alignment)) return ALIGN_RIGHT;
+        return alignment;
     }
-    
+
     /** returns table's HTML code, table is ordered by ordCol-th column */
     public String printTable(int ordCol) {
         String lastLine[] = new String[Math.max(iColumns,(iHeaders==null?0:iHeaders.length))];
         StringBuffer sb = new StringBuffer();
         boolean rtl = Localization.isRTL();
-        
-        if (iName != null && iName.trim().length()>0) {
-            sb.append("<tr><td "+ COLSPAN + iColumns
-                    + "><div class=WelcomeRowHead>" + iName + "</div></td></tr>");
-        }
+
+        appendNameRow(sb);
 
         sb.append("<tr><td colspan='" + iColumns + "'><div class='unitime-LegacyWebTable'><table width='100%' border='0' cellspacing='0' cellpadding='3'>");
-        
-        boolean asc = (ordCol == 0 || iAsc == null
-                || iAsc.length <= Math.abs(ordCol) - 1
-                ? true
-                : iAsc[Math.abs(ordCol) - 1]);
 
-        if (ordCol < 0) {
-            asc = !asc;
-        }
-        if (iHeaders != null) {
-            sb.append("<tr valign='top'>");
-            int last = iColumns - iHeaders.length + 1;
+        boolean asc = resolveAsc(ordCol);
 
-            for (int i = 0; i < iHeaders.length; i++) {
-                if (!isFiltered(i)) {
-                    if (iHeaders[i] != null) {
-                        String header = ToolBox.replace((iRef == null
-                                || iLines.size() == 0
-                                || ((WebTableLine) iLines.elementAt(0)).getOrderBy()
-                                        == null
-                                || ((WebTableLine) iLines.elementAt(0)).getOrderBy()[i]
-                                        == null
-                                ? iHeaders[i]
-                                : "<A title=\"Order by this column.\" href=\""
-                                	+ iRef + "\" class=\"sortHeader\">"
-                                	+ (i == Math.abs(ordCol) - 1 ? (asc ? "&uarr;" : "&darr;") : "")
-                                			/*
-                                            ? "<img class='WebTableOrderArrow' src='"
-                                                    + (asc
-                                                            ? IMG_ASC
-                                                            : IMG_DEC)
-                                                    + "' border='0'>"
-                                            : "") */ 
-                                    + iHeaders[i]
-                                    + "</A>"
-                                        ),
-                                "%%",
-                                String.valueOf(i == Math.abs(ordCol) - 1
-                                ? -ordCol
-                                : i + 1));
+        appendHeaderRow(sb, ordCol, asc, rtl);
 
-                        sb.append("<td align=\""
-                                + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? ALIGN_RIGHT : "left")) + "\""
-                                + (i == iHeaders.length - 1
-                                        ? COLSPAN + last + " "
-                                        : "") + " class=\"WebTableHeader\">" + header + "</td>");
-                    } else {
-                        sb.append("<td class=\"WebTableHeader\" "
-                                + (i == iHeaders.length - 1
-                                        ? COLSPAN + last + " "
-                                        : "")
-                                + ">&nbsp;</td>");
-                    }
-                }
-            }
-            sb.append("</tr>");
-        }
-        if (ordCol != 0) {
-            Collections.sort(iLines,
-                    new WebTableComparator(Math.abs(ordCol) - 1, asc));
-        }
-        for (int el = 0; el < iLines.size(); el++) {
-            WebTableLine wtline = (WebTableLine) iLines.elementAt(el);
-            String[] line = wtline.getLine();
-            String onClick = wtline.getOnClick();
-            String lineStyle = wtline.getStyle();
-            String bgColor = wtline.getBgColor();
-            if (bgColor != null) {
-            	if (lineStyle == null)
-            		lineStyle = "background-color:" + bgColor + ";";
-            	else
-            		lineStyle += "background-color:" + bgColor + ";";
-            }
-            String title = wtline.getTitle();
-            String style = getStyle(wtline, (el+1<iLines.size()?(WebTableLine)iLines.elementAt(el+1):null), ordCol);
-            int last = iColumns - line.length + 1;
-            boolean anchor = (onClick != null && onClick.startsWith("<"));
 
-			sb.append("\n");
-            sb.append((anchor ? onClick : "") + "<tr valign='top' "
-                    + (onClick == null || anchor ? "" : onClick)
-                    + (lineStyle == null ? "" : " style='" + lineStyle + "'")
-                    + (!suppressRowHighlight ? " onmouseover=\"this.style.backgroundColor='rgb(223,231,242)';" : "") 
-                    + "this.style.cursor='"
-                    + (onClick == null ? "default" : "hand") 
-                    + (onClick != null ? "';this.style.cursor='pointer" : "")
-                    + "';\"" 
-                    + (!suppressRowHighlight ? "onmouseout=\"this.style.backgroundColor='"+(bgColor==null?"transparent":bgColor)+"';\"" : "")
-                    + (title == null ? "" : " title='" + title + "'")
-                    + (onClick != null && !anchor ? " tabindex='0' height='24px' onkeydown='if (window.event.keyCode == 13) this.click();'": "")
-                    + ">");
-            boolean blank = iBlankWhenSame;
-            for (int i = 0; i < line.length; i++) {
-                if (!isFiltered(i)) {
-                    if (blank && line[i]!=null && !line[i].equals(lastLine[i]))
-                        blank=false;
-                    if (!blank && line[i] != null) {
-                        sb.append("<td "
-                                + getCellStyle(wtline, i, style)
-                                + " align=\""
-                                + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? ALIGN_RIGHT : "left"))
-                                + "\""
-                                + (i == line.length - 1
-                                        ? COLSPAN + last + " "
-                                        : "")
-                                + ">"
-                                + (i == 0 && wtline.getUniqueId() != null ? "<A name=\""+wtline.iUniqueId+"\" ></A>" : "")
-                                + line[i]
-                                + "</td>");
-                    } else {
-                        sb.append("<td "
-                        		+ getCellStyle(wtline, i, style)
-                                + " "
-                                + (i == line.length - 1
-                                        ? COLSPAN + last + " "
-                                        : "")
-                                + ">&nbsp;</td>");
-                    }
-                    if (i<lastLine.length) lastLine[i] = line[i]; 
-                }
-            }
-            sb.append("</tr>" + (anchor ? "</a>" : ""));
-        }
-        
+        appendAllRows(sb, ordCol, asc, lastLine, rtl);
+
         sb.append("</table></div></td></tr>");
-        
+
         return sb.toString();
     }
-    
+
+    private void appendCsvLines(CSVFile file, String[] lastLine) {
+        for (Enumeration el = iLines.elements(); el.hasMoreElements();) {
+            WebTableLine wtline = (WebTableLine) el.nextElement();
+            String[] line = wtline.getLine();
+            Vector cline = new Vector();
+            boolean blank = iBlankWhenSame;
+            for (int i = 0; i < line.length; i++) {
+                if (isFiltered(i)) continue;
+                if (blank && line[i] != null && !line[i].equals(lastLine[i])) blank = false;
+                cline.add(new CSVField(blank || line[i] == null ? "" : line[i]));
+                lastLine[i] = line[i];
+            }
+            file.addLine(cline);
+        }
+    }
+
     public CSVFile toCSVFile(int ordCol) {
         CSVFile file = new CSVFile();
         if (iHeaders != null) {
@@ -427,35 +324,21 @@ public class WebTable {
         if (ordCol < 0) asc = !asc;
         if (ordCol != 0) Collections.sort(iLines, new WebTableComparator(Math.abs(ordCol) - 1, asc));
         String lastLine[] = new String[Math.max(iColumns,(iHeaders==null?0:iHeaders.length))];
-        for (Enumeration el = iLines.elements(); el.hasMoreElements();) {
-            WebTableLine wtline = (WebTableLine) el.nextElement();
-            String[] line = wtline.getLine();
-            Vector cline = new Vector();
-            boolean blank = iBlankWhenSame;
-            for (int i=0; i<line.length; i++) {
-                if (isFiltered(i)) continue;
-                if (blank && line[i]!=null && !line[i].equals(lastLine[i])) blank=false;
-
-                cline.add(new CSVField(blank || line[i]==null?"":line[i]));
-                lastLine[i] = line[i];
-            }
-            file.addLine(cline);
-        }
+        appendCsvLines(file, lastLine);
         return file;
     }
-    
     public int getNrColumns() {
         return iColumns - getNrFilteredColumns();
     }
-    
+
     public String[] getHeader() {
         return iHeaders;
     }
-    
+
     public boolean isBlankWhenSame() {
         return iBlankWhenSame;
     }
-    
+
     public void setBlankWhenSame(boolean blankWhenSame) {
         iBlankWhenSame = blankWhenSame;
     }
@@ -471,14 +354,14 @@ public class WebTable {
 
         /** onclick event */
         private String iOnClick = null;
-        
+
         /** String uniquely identifying the line */
         private String iUniqueId = null;
-        
+
         private String iBgColor = null;
         private String iStyle = null;
         private String iTitle = null;
-        
+
         /** constructor */
         WebTableLine(String onClick, String[] line, Comparable[] orderby) {
             iOnClick = onClick;
@@ -486,12 +369,12 @@ public class WebTable {
             iOrderBy = orderby;
         }
 
-		/** constructor */
-		 WebTableLine(String onClick, String[] line, Comparable[] orderby, String uniqueId) {
-		 	this(onClick, line, orderby);
-			iUniqueId = uniqueId;
-		 }
-        
+        /** constructor */
+        WebTableLine(String onClick, String[] line, Comparable[] orderby, String uniqueId) {
+            this(onClick, line, orderby);
+            iUniqueId = uniqueId;
+        }
+
         public String getOnClick() {
             return iOnClick;
         }
@@ -499,11 +382,11 @@ public class WebTable {
         public String[] getLine() {
             return iLine;
         }
-        
+
         public Comparable[] getOrderBy() {
             return iOrderBy;
         }
-        
+
         /** compare two lines according to the given column and order direction */
         public int compareTo(WebTableLine another, int column, boolean asc) {
             if (column < 0 || iOrderBy == null || iOrderBy.length <= column) {
@@ -519,11 +402,11 @@ public class WebTable {
             int ret = (a == null
                     ? (b == null ? 0 : -1)
                     : b == null
-                            ? 1
-                            : a instanceof String && b instanceof String
-                                    ? (asc ? 1 : -1)
-                                            * noc.compare((String) a, (String) b)
-                                    : (asc ? 1 : -1) * a.compareTo(b));
+                    ? 1
+                    : a instanceof String && b instanceof String
+                    ? (asc ? 1 : -1)
+                    * noc.compare((String) a, (String) b)
+                    : (asc ? 1 : -1) * a.compareTo(b));
 
             if (ret != 0) {
                 return ret;
@@ -534,69 +417,69 @@ public class WebTable {
                 ret = (a == null
                         ? (b == null ? 0 : -1)
                         : b == null
-                                ? 1
-                                : a instanceof String && b instanceof String
-                                        ? (asc ? 1 : -1)
-                                                * noc.compare((String) a, (String) b)
-                                        : (asc ? 1 : -1) * a.compareTo(b));
+                        ? 1
+                        : a instanceof String && b instanceof String
+                        ? (asc ? 1 : -1)
+                        * noc.compare((String) a, (String) b)
+                        : (asc ? 1 : -1) * a.compareTo(b));
                 if (ret != 0) {
                     return ret;
                 }
             }
             return ret;
         }
-        
-		/**
-		 * @return
-		 */
-		public String getUniqueId() {
-			return iUniqueId;
-		}
 
-		/**
-		 * @param String
-		 */
-		public void setUniqueId(String uniqueId) {
-			iUniqueId = uniqueId;
-		}
-        
+        /**
+         * @return
+         */
+        public String getUniqueId() {
+            return iUniqueId;
+        }
+
+        /**
+         * @param String
+         */
+        public void setUniqueId(String uniqueId) {
+            iUniqueId = uniqueId;
+        }
+
         public void setBgColor(String bgColor) {
             iBgColor = bgColor;
         }
-        
+
         public String getBgColor() {
             return iBgColor;
         }
 
         public void setTitle(String title) {
-        	iTitle = title;
+            iTitle = title;
         }
-        
+
         public String getTitle() {
-        	return iTitle;
+            return iTitle;
         }
-        
+
         public void setStyle(String style) {
-        	iStyle = style;
+            iStyle = style;
         }
-        
+
         public String getStyle() {
-        	return iStyle;
+            return iStyle;
         }
     }
-    
+
 
     /** Table lines comparator */
     public static class WebTableComparator implements Comparator {
         private int iColumn = 1;
         private boolean iAsc = true;
-        
+
         /** constructor -- order column and order direction */
         public WebTableComparator(int column, boolean asc) {
             iColumn = column;
             iAsc = asc;
         }
-        
+
         /** compares two lines */
         public int compare(Object o1, Object o2) {
             if (o1 == null || o2 == null || !(o1 instanceof WebTableLine)
@@ -608,7 +491,7 @@ public class WebTable {
 
             return w1.compareTo(w2, iColumn, iAsc);
         }
-        
+
         /** compares two lines */
         public boolean equals(Object obj) {
             if (obj == null || !(obj instanceof WebTableComparator)) {
@@ -619,8 +502,8 @@ public class WebTable {
             return (wtc.iAsc == iAsc && wtc.iColumn == iColumn);
         }
     }
-    
-    /** get order (index of ordered column) for given session and table 
+
+    /** get order (index of ordered column) for given session and table
      * @param context session context
      * @param code table code
      * @return index of ordered column (negative for desc.) */
@@ -633,23 +516,23 @@ public class WebTable {
         return (orderInfo.containsKey(code)?((Integer)orderInfo.get(code)).intValue():0);
     }
 
-    /** set order (index of ordered column) for given session and table 
+    /** set order (index of ordered column) for given session and table
      * @param context session context
      * @param code table code
      * @param order new order (index of ordered column, negative if desc.)
-     * @param defOrder default order (if order is null) 
+     * @param defOrder default order (if order is null)
      */
     public static void setOrder(SessionContext context, String code, String order, int defOrder) {
         Hashtable orderInfo = (Hashtable)context.getAttribute(SessionAttribute.TableOrder);
         if (orderInfo==null) {
             orderInfo = new Hashtable();
             context.setAttribute(SessionAttribute.TableOrder, orderInfo);
-        } 
+        }
         if (order!=null) orderInfo.put(code,Integer.valueOf(order));
         else if (!orderInfo.containsKey(code)) orderInfo.put(code,Integer.valueOf(defOrder));
     }
 
-    /** set order (index of ordered column) for given session and table 
+    /** set order (index of ordered column) for given session and table
      * @param session session
      * @param code table code
      * @param order new order (index of ordered column, negative if desc.)
@@ -663,88 +546,216 @@ public class WebTable {
         }
         orderInfo.put(code,Integer.valueOf(order));
     }
-    
-    
+
+
     public Vector getLines() {
         return iLines;
     }
-    
+
     public void setRef(String ref) { iRef = ref; }
     public void setName(String name) { iName = name; }
-    
+
     public static interface WebTableTweakStyle {
-    	public String getStyleHtml(WebTableLine currentLine, WebTableLine nextLine, int orderBy);
+        public String getStyleHtml(WebTableLine currentLine, WebTableLine nextLine, int orderBy);
     }
-    
+
     public static interface WebTableCellStyle {
-    	public String getCellStyleHtml(WebTableLine currentLine, int column);
+        public String getCellStyleHtml(WebTableLine currentLine, int column);
     }
-    
-	protected CSVField csvField(String text) {
-		if (text == null) return new CSVField("");
-		if (text.indexOf("@@")<0) return new CSVField(text); 
-		
-		String cell = "";
-		boolean first = true;
-		for (StringTokenizer s = new StringTokenizer(text,"\n"); s.hasMoreTokens();) {
-			String line = s.nextToken();
-			int pos = 0;
-			while (true) {
-				int idx = line.indexOf("@@", pos);
-				if (idx < 0) {
-					cell += (!first && pos==0?"\n":"") + line.substring(pos);
-					break;
-				} else {
-					cell += (!first && pos==0?"\n":"") + line.substring(pos, idx);
-					pos = idx;
-				}
-				pos+=2; //for @@
-				String cmd = line.substring(pos, line.indexOf(' ',pos));
-				pos+=cmd.length()+1;
-				if ("COLOR".equals(cmd)) {
-					String hex = line.substring(pos, line.indexOf(' ',pos));
-					pos+=hex.length()+1;
-					if (hex.startsWith("#")) hex = hex.substring(1);
-				}
+
+    protected CSVField csvField(String text) {
+        if (text == null) return new CSVField("");
+        if (text.indexOf("@@")<0) return new CSVField(text);
+
+        String cell = "";
+        boolean first = true;
+        for (StringTokenizer s = new StringTokenizer(text,"\n"); s.hasMoreTokens();) {
+            String line = s.nextToken();
+            int pos = 0;
+            while (true) {
+                int idx = line.indexOf("@@", pos);
+                if (idx < 0) {
+                    cell += (!first && pos==0?"\n":"") + line.substring(pos);
+                    break;
+                } else {
+                    cell += (!first && pos==0?"\n":"") + line.substring(pos, idx);
+                    pos = idx;
+                }
+                pos+=2; //for @@
+                String cmd = line.substring(pos, line.indexOf(' ',pos));
+                pos+=cmd.length()+1;
+                if ("COLOR".equals(cmd)) {
+                    String hex = line.substring(pos, line.indexOf(' ',pos));
+                    pos+=hex.length()+1;
+                    if (hex.startsWith("#")) hex = hex.substring(1);
+                }
                 if ("BGCOLOR".equals(cmd)) {
                     String hex = line.substring(pos, line.indexOf(' ',pos));
                     pos+=hex.length()+1;
-					if (hex.startsWith("#")) hex = hex.substring(1);
+                    if (hex.startsWith("#")) hex = hex.substring(1);
                 }
-				if ("IMAGE".equals(cmd)) {
-					String name = line.substring(pos, line.indexOf(' ',pos));
-					pos+=name.length()+1;
-				}
-				if ("BORDER_ALL".equals(cmd) 
-						|| "BORDER_TOP".equals(cmd)	|| "BORDER_BOTTOM".equals(cmd) 
-						|| "BORDER_LEFT".equals(cmd) || "BORDER_RIGHT".equals(cmd) ) {
-					
-					String hex = line.substring(pos, line.indexOf(' ',pos));
-					pos+=hex.length()+1;
-					if (hex.startsWith("#")) hex = hex.substring(1);
-				}
-			}
-			first=false;
-		}
-		
-		return new CSVField(cell);
-	}
-	
-	/**
-	 * Prints csv table.
-	 * @param ordCol
-	 * @return
-	 */
-	public CSVFile printCsvTable(int ordCol) {
-		CSVFile csv = new CSVFile();
-    	
+                if ("IMAGE".equals(cmd)) {
+                    String name = line.substring(pos, line.indexOf(' ',pos));
+                    pos+=name.length()+1;
+                }
+                if ("BORDER_ALL".equals(cmd)
+                        || "BORDER_TOP".equals(cmd)	|| "BORDER_BOTTOM".equals(cmd)
+                        || "BORDER_LEFT".equals(cmd) || "BORDER_RIGHT".equals(cmd) ) {
+
+                    String hex = line.substring(pos, line.indexOf(' ',pos));
+                    pos+=hex.length()+1;
+                    if (hex.startsWith("#")) hex = hex.substring(1);
+                }
+            }
+            first=false;
+        }
+
+        return new CSVField(cell);
+    }
+
+    private void appendHeaderCell(StringBuffer sb, int i, int last, int ordCol, boolean asc, boolean rtl) {
+        if (iHeaders[i] != null) {
+            String header = ToolBox.replace(buildHeaderText(i, ordCol, asc), "%%", String.valueOf(i == Math.abs(ordCol) - 1 ? -ordCol : i + 1));
+            sb.append("<td align=\""
+                    + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? ALIGN_RIGHT : "left")) + "\""
+                    + (i == iHeaders.length - 1 ? COLSPAN + last + " " : "")
+                    + " class=\"WebTableHeader\">" + header + "</td>");
+        } else {
+            sb.append("<td class=\"WebTableHeader\" "
+                    + (i == iHeaders.length - 1 ? COLSPAN + last + " " : "")
+                    + ">&nbsp;</td>");
+        }
+    }
+
+    private String buildHeaderText(int i, int ordCol, boolean asc) {
+        return (iRef == null
+                || iLines.size() == 0
+                || ((WebTableLine) iLines.elementAt(0)).getOrderBy() == null
+                || ((WebTableLine) iLines.elementAt(0)).getOrderBy()[i] == null
+                ? iHeaders[i]
+                : "<A title=\"Order by this column.\" href=\""
+                + iRef + "\" class=\"sortHeader\">"
+                + (i == Math.abs(ordCol) - 1 ? (asc ? "&uarr;" : "&darr;") : "")
+                + iHeaders[i]
+                + "</A>");
+    }
+
+    private void appendRowOpen(StringBuffer sb, String onClick, boolean anchor, String lineStyle, String bgColor, String title) {
+        sb.append((anchor ? onClick : "") + "<tr valign='top' "
+                + (onClick == null || anchor ? "" : onClick)
+                + (lineStyle == null ? "" : " style='" + lineStyle + "'")
+                + (!suppressRowHighlight ? " onmouseover=\"this.style.backgroundColor='rgb(223,231,242)';" : "")
+                + "this.style.cursor='"
+                + (onClick == null ? "default" : "hand")
+                + (onClick != null ? "';this.style.cursor='pointer" : "")
+                + "';\""
+                + (!suppressRowHighlight ? "onmouseout=\"this.style.backgroundColor='" + (bgColor == null ? "transparent" : bgColor) + "';\"" : "")
+                + (title == null ? "" : " title='" + title + "'")
+                + (onClick != null && !anchor ? " tabindex='0' height='24px' onkeydown='if (window.event.keyCode == 13) this.click();'" : "")
+                + ">");
+    }
+
+    private void appendDataCell(StringBuffer sb, WebTableLine wtline, String[] line, int i, int last, String style, boolean blank, boolean rtl) {
+        if (!blank && line[i] != null) {
+            sb.append("<td "
+                    + getCellStyle(wtline, i, style)
+                    + " align=\""
+                    + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? ALIGN_RIGHT : "left"))
+                    + "\""
+                    + (i == line.length - 1 ? COLSPAN + last + " " : "")
+                    + ">"
+                    + (i == 0 && wtline.getUniqueId() != null ? "<A name=\"" + wtline.iUniqueId + "\" ></A>" : "")
+                    + line[i]
+                    + "</td>");
+        } else {
+            sb.append("<td "
+                    + getCellStyle(wtline, i, style)
+                    + " "
+                    + (i == line.length - 1 ? COLSPAN + last + " " : "")
+                    + ">&nbsp;</td>");
+        }
+    }
+
+    private boolean resolveAsc(int ordCol) {
+        boolean asc = (ordCol == 0 || iAsc == null
+                || iAsc.length <= Math.abs(ordCol) - 1
+                ? true
+                : iAsc[Math.abs(ordCol) - 1]);
+        if (ordCol < 0) asc = !asc;
+        return asc;
+    }
+
+    private void appendNameRow(StringBuffer sb) {
+        if (iName != null && iName.trim().length() > 0) {
+            sb.append("<tr><td " + COLSPAN + iColumns
+                    + "><div class=WelcomeRowHead>" + iName + "</div></td></tr>");
+        }
+    }
+
+    private void appendHeaderRow(StringBuffer sb, int ordCol, boolean asc, boolean rtl) {
+        if (iHeaders == null) return;
+        sb.append("<tr valign='top'>");
+        int last = iColumns - iHeaders.length + 1;
+        for (int i = 0; i < iHeaders.length; i++) {
+            if (!isFiltered(i)) {
+                appendHeaderCell(sb, i, last, ordCol, asc, rtl);
+            }
+        }
+        sb.append("</tr>");
+    }
+
+    private void appendAllRows(StringBuffer sb, int ordCol, boolean asc, String[] lastLine, boolean rtl) {
+        if (ordCol != 0) {
+            Collections.sort(iLines, new WebTableComparator(Math.abs(ordCol) - 1, asc));
+        }
+        for (int el = 0; el < iLines.size(); el++) {
+            WebTableLine wtline = (WebTableLine) iLines.elementAt(el);
+            String[] line = wtline.getLine();
+            String onClick = wtline.getOnClick();
+            String lineStyle = wtline.getStyle();
+            String bgColor = wtline.getBgColor();
+            if (bgColor != null) {
+                lineStyle = (lineStyle == null ? "" : lineStyle) + "background-color:" + bgColor + ";";
+            }
+            String title = wtline.getTitle();
+            String style = getStyle(wtline, (el + 1 < iLines.size() ? (WebTableLine) iLines.elementAt(el + 1) : null), ordCol);
+            int last = iColumns - line.length + 1;
+            boolean anchor = (onClick != null && onClick.startsWith("<"));
+
+            sb.append("\n");
+            appendRowOpen(sb, onClick, anchor, lineStyle, bgColor, title);
+            appendRowCells(sb, wtline, line, last, style, lastLine, rtl);
+            sb.append("</tr>" + (anchor ? "</a>" : ""));
+        }
+    }
+
+    private void appendRowCells(StringBuffer sb, WebTableLine wtline, String[] line, int last, String style, String[] lastLine, boolean rtl) {
+        boolean blank = iBlankWhenSame;
+        for (int i = 0; i < line.length; i++) {
+            if (!isFiltered(i)) {
+                if (blank && line[i] != null && !line[i].equals(lastLine[i]))
+                    blank = false;
+                appendDataCell(sb, wtline, line, i, last, style, blank, rtl);
+                if (i < lastLine.length) lastLine[i] = line[i];
+            }
+        }
+    }
+
+    /**
+     * Prints csv table.
+     * @param ordCol
+     * @return
+     */
+    public CSVFile printCsvTable(int ordCol) {
+        CSVFile csv = new CSVFile();
+
         boolean asc = (ordCol == 0 || iAsc == null || iAsc.length <= Math.abs(ordCol) - 1 ? true : iAsc[Math.abs(ordCol) - 1]);
         if (ordCol < 0) asc = !asc;
 
         String lastLine[] = new String[Math.max(iColumns,(iHeaders==null?0:iHeaders.length))];
-        
+
         if (iHeaders != null) {
-        	List<CSVField> line = new ArrayList<CSVField>();
+            List<CSVField> line = new ArrayList<CSVField>();
             for (int i = 0; i < iColumns; i++) {
                 if (isFiltered(i)) continue;
                 line.add(csvField(iHeaders[i]));
@@ -762,11 +773,11 @@ public class WebTable {
                 if (isFiltered(i)) continue;
                 if (blank && wtline.getLine()[i]!=null && !wtline.getLine()[i].equals(lastLine[i])) blank=false;
                 line.add(csvField(wtline.getLine()[i]));
-            	lastLine[i] = wtline.getLine()[i];
+                lastLine[i] = wtline.getLine()[i];
             }
             csv.addLine(line);
         }
-        
+
         return csv;
     }
 }

--- a/JavaSource/org/unitime/commons/web/WebTable.java
+++ b/JavaSource/org/unitime/commons/web/WebTable.java
@@ -87,6 +87,9 @@ public class WebTable {
     
     protected WebTableTweakStyle iWebTableTweakStyle = null;
     protected WebTableCellStyle iWebTableCellStyle = null;
+
+    private static final String ALIGN_RIGHT = "right";
+    private static final String COLSPAN = " colspan=";
     
     /** creates a WebTable instance */
     public WebTable(int columns, String name, String[] headers, String[] align, boolean[] asc) {
@@ -266,7 +269,7 @@ public class WebTable {
     }
     
     protected static String align(String alignment, boolean rtl) {
-    	if (rtl && "left".equalsIgnoreCase(alignment)) return "right";
+    	if (rtl && "left".equalsIgnoreCase(alignment)) return ALIGN_RIGHT;
     	return alignment;
     }
     
@@ -277,7 +280,7 @@ public class WebTable {
         boolean rtl = Localization.isRTL();
         
         if (iName != null && iName.trim().length()>0) {
-            sb.append("<tr><td colspan=" + iColumns
+            sb.append("<tr><td "+ COLSPAN + iColumns
                     + "><div class=WelcomeRowHead>" + iName + "</div></td></tr>");
         }
 
@@ -324,14 +327,14 @@ public class WebTable {
                                 : i + 1));
 
                         sb.append("<td align=\""
-                                + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? "right" : "left")) + "\""
+                                + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? ALIGN_RIGHT : "left")) + "\""
                                 + (i == iHeaders.length - 1
-                                        ? " colspan=" + last + " "
+                                        ? COLSPAN + last + " "
                                         : "") + " class=\"WebTableHeader\">" + header + "</td>");
                     } else {
                         sb.append("<td class=\"WebTableHeader\" "
                                 + (i == iHeaders.length - 1
-                                        ? " colspan=" + last + " "
+                                        ? COLSPAN + last + " "
                                         : "")
                                 + ">&nbsp;</td>");
                     }
@@ -382,10 +385,10 @@ public class WebTable {
                         sb.append("<td "
                                 + getCellStyle(wtline, i, style)
                                 + " align=\""
-                                + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? "right" : "left"))
+                                + (iAlign != null ? align(iAlign[i], rtl) : (rtl ? ALIGN_RIGHT : "left"))
                                 + "\""
                                 + (i == line.length - 1
-                                        ? " colspan=" + last + " "
+                                        ? COLSPAN + last + " "
                                         : "")
                                 + ">"
                                 + (i == 0 && wtline.getUniqueId() != null ? "<A name=\""+wtline.iUniqueId+"\" ></A>" : "")
@@ -396,7 +399,7 @@ public class WebTable {
                         		+ getCellStyle(wtline, i, style)
                                 + " "
                                 + (i == line.length - 1
-                                        ? " colspan=" + last + " "
+                                        ? COLSPAN + last + " "
                                         : "")
                                 + ">&nbsp;</td>");
                     }

--- a/JavaSource/org/unitime/timetable/action/ClassEditAction.java
+++ b/JavaSource/org/unitime/timetable/action/ClassEditAction.java
@@ -88,6 +88,8 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
 	private static final long serialVersionUID = 8307712785352190036L;
 	protected final static CourseMessages MSG = Localization.create(CourseMessages.class);
 
+	private static final String DISPLAY_CLASS_DETAIL = "displayClassDetail";
+
 	protected String classId = null;
 	protected String op2 = null;
 	protected String deleteType = null;
@@ -181,7 +183,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
 
         // Cancel - Go back to Class Detail Screen
         if (MSG.actionBackToDetail().equals(op)) {
-        	return "displayClassDetail";
+        	 return DISPLAY_CLASS_DETAIL;
         }
 
         // If class id is not null - load class info
@@ -222,7 +224,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
                     c.getSchedulingSubpart().getInstrOfferingConfig().getInstructionalOffering().getControllingCourseOffering().getSubjectArea(),
                     c.getManagingDept());
 
-            return "displayClassDetail";
+			return DISPLAY_CLASS_DETAIL;
         }
 
         // Reset form for initial load
@@ -276,7 +278,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
     	            	return null;
     	            }
 
-    	            return "displayClassDetail";
+					return DISPLAY_CLASS_DETAIL;
             	} catch (Exception e) {
             		tx.rollback(); throw e;
             	}

--- a/JavaSource/org/unitime/timetable/action/ClassEditAction.java
+++ b/JavaSource/org/unitime/timetable/action/ClassEditAction.java
@@ -15,7 +15,7 @@
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 */
 package org.unitime.timetable.action;
 
@@ -72,7 +72,7 @@ import org.unitime.timetable.webutil.BackTracker;
 @Action(value = "classEdit", results = {
 		@Result(name = "editClass", type = "tiles", location = "classEditTile.tiles"),
 		@Result(name = "instructionalOfferingSearch", type = "redirect", location = "/instructionalOfferingSearch.action"),
-		@Result(name = "addDistributionPrefs", type = "redirect", location = "/distributionPrefs.action", 
+		@Result(name = "addDistributionPrefs", type = "redirect", location = "/distributionPrefs.action",
 			params = { "classId", "${form.classId}", "op", "${op}"}
 		),
 		@Result(name = "displayClassDetail", type = "redirect", location = "/classDetail.action",
@@ -98,7 +98,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
 	public String getCid() { return classId; }
 	public void setCid(String classId) { this.classId = classId; }
 	public String getOp2() { return op2; }
-	public void setOp2(String op2) { this.op2 = op2; }	
+	public void setOp2(String op2) { this.op2 = op2; }
 	public String getDeleteType() { return deleteType; }
 	public void setDeleteType(String deleteType) { this.deleteType = deleteType; }
 	public Long getDeleteId() { return deleteId; }
@@ -108,17 +108,8 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
     public final String HASH_INSTRUCTORS = "Instructors";
 
     public String execute() throws Exception {
-    	if (ApplicationProperty.LegacyClassEdit.isFalse()) {
-    		String url = "classEdit";
-    		boolean first = true;
-    		for (Enumeration<String> e = getRequest().getParameterNames(); e.hasMoreElements(); ) {
-    			String param = e.nextElement();
-    			url += (first ? "?" : "&") + param + "=" + URLEncoder.encode(getRequest().getParameter(param), "utf-8");
-    			first = false;
-    		}
-    		response.sendRedirect(url);
-			return null;
-    	}
+		if (handleLegacyRedirect()) return null;
+
     	if (form == null) form = new ClassEditForm();
 
 		super.execute();
@@ -126,58 +117,26 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
 		if (classId == null && request.getAttribute("cid") != null)
 			classId = (String)request.getAttribute("cid");
 
-		if (op == null) op = form.getOp();
-        if (op2 != null && !op2.isEmpty()) op = op2;
+		initializeOp();
 
 
         // Read class id from form
-        if (MSG.actionAddTimePreference().equals(op)
-                || MSG.actionAddRoomPreference().equals(op)
-                || MSG.actionAddBuildingPreference().equals(op)
-                || MSG.actionAddRoomFeaturePreference().equals(op)
-                || MSG.actionAddDistributionPreference().equals(op)
-                || MSG.actionAddInstructor().equals(op)
-                || MSG.actionUpdatePreferences().equals(op)
-                || MSG.actionAddDatePatternPreference().equals(op)
-                || MSG.actionAddAttributePreference().equals(op)
-                || MSG.actionAddInstructorPreference().equals(op)
-                || MSG.actionClearClassPreferences().equals(op)
-                || MSG.actionRemoveBuildingPreference().equals(op)
-        		|| MSG.actionRemoveDistributionPreference().equals(op)
-        		|| MSG.actionRemoveRoomFeaturePreference().equals(op)
-        		|| MSG.actionRemoveRoomGroupPreference().equals(op)
-        		|| MSG.actionRemoveRoomPreference().equals(op)
-        		|| MSG.actionRemoveDatePatternPreference().equals(op)
-        		|| MSG.actionRemoveTimePattern().equals(op)
-        		|| MSG.actionRemoveInstructor().equals(op)
-        		|| MSG.actionRemoveAttributePreference().equals(op)
-        		|| MSG.actionRemoveInstructorPreference().equals(op)
-                || MSG.actionAddRoomGroupPreference().equals(op)
-                || MSG.actionBackToDetail().equals(op)
-                || MSG.actionNextClass().equals(op)
-                || MSG.actionPreviousClass().equals(op)
-                || "updateDatePattern".equals(op)
-                || "updatePref".equals(op)) {
-            classId = form.getClassId().toString();
-        }
+		if (shouldReadClassIdFromForm(op)) {
+			classId = form.getClassId().toString();
+		}
 
         // Determine if initial load
         if (op==null || op.trim().isEmpty()) {
             op = "init";
         }
-        
+
         boolean timeVertical = CommonValues.VerticalGrid.eq(sessionContext.getUser().getProperty(UserProperty.GridOrientation));
 
         Debug.debug("op: " + op);
         Debug.debug("class: " + classId);
 
         // Check class exists
-        if (classId==null || classId.trim().isEmpty()) {
-           if (BackTracker.doBack(request, response))
-        	   return null;
-           else
-        	   throw new Exception(MSG.errorClassInfoNotSupplied());
-        }
+		if (isClassIdMissing()) return null;
 
         sessionContext.checkPermission(classId, "Class_", Right.ClassEdit);
 
@@ -196,183 +155,41 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
             return "addDistributionPrefs";
 	    }
 
-	    // Add Instructor
-	    if(MSG.actionAddInstructor().equals(op))
-            addInstructor();
-
-	    // Delete Instructor
-        if (MSG.actionRemoveInstructor().equals(op) && "instructor".equals(deleteType))
-            deleteInstructor();
+		handleInstructorOperations(c);
 
         // Restore all inherited preferences
-        if (MSG.actionClearClassPreferences().equals(op)) {
-        	sessionContext.checkPermission(c, Right.ClassEditClearPreferences);
-
-            Set s = c.getPreferences();
-            doClear(s, Preference.Type.TIME, Preference.Type.ROOM, Preference.Type.ROOM_FEATURE, Preference.Type.ROOM_GROUP, Preference.Type.BUILDING, Preference.Type.DATE);
-            c.setPreferences(s);
-            cdao.getSession().merge(c);
-            cdao.getSession().flush();
-            op = "init";
-
-            ChangeLog.addChange(
-                    null,
-                    sessionContext,
-                    c,
-                    ChangeLog.Source.CLASS_EDIT,
-                    ChangeLog.Operation.CLEAR_PREF,
-                    c.getSchedulingSubpart().getInstrOfferingConfig().getInstructionalOffering().getControllingCourseOffering().getSubjectArea(),
-                    c.getManagingDept());
-
-			return DISPLAY_CLASS_DETAIL;
-        }
+		if (MSG.actionClearClassPreferences().equals(op)) {
+			return handleClearPreferences(c, cdao);
+		}
 
         // Reset form for initial load
-        if ("init".equals(op)) {
-            form.reset();
-        }
+		resetFormIfInit();
 
         // Load form attributes that are constant
         doLoad(c, op);
 
         // Update Preferences for Class
-        if (MSG.actionUpdatePreferences().equals(op) || MSG.actionNextClass().equals(op) || MSG.actionPreviousClass().equals(op)) {
-            // Validate input prefs
-            form.validate(this);
-
-            // No errors - Add to class and update
-            if (!hasFieldErrors()) {
-
-            	org.hibernate.Session hibSession = cdao.getSession();
-            	Transaction tx = hibSession.beginTransaction();
-
-            	try {
-                    // Clear all old prefs
-                    Set s = c.getPreferences();
-                    doClear(s, Preference.Type.TIME, Preference.Type.ROOM, Preference.Type.ROOM_FEATURE, Preference.Type.ROOM_GROUP, Preference.Type.BUILDING, Preference.Type.DATE);
-
-                    // Save class data
-                    doUpdate(c, hibSession);
-
-                    // Save Prefs
-                    super.doUpdate(c, s, timeVertical,
-                    		Preference.Type.TIME, Preference.Type.ROOM, Preference.Type.ROOM_FEATURE, Preference.Type.ROOM_GROUP, Preference.Type.BUILDING, Preference.Type.DATE);
-                    
-                    hibSession.merge(c);
-
-    	            tx.commit();
-    	            
-                    String className = ApplicationProperty.ExternalActionClassEdit.value();
-                	if (className != null && className.trim().length() > 0){
-                    	ExternalClassEditAction editAction = (ExternalClassEditAction) (Class.forName(className).getDeclaredConstructor().newInstance());
-                   		editAction.performExternalClassEditAction(c, hibSession);
-                	}
-
-    	            if (MSG.actionNextClass().equals(op)) {
-    	            	response.sendRedirect(response.encodeURL("classEdit.action?cid="+form.getNextId()));
-    	            	return null;
-    	            }
-
-    	            if (MSG.actionPreviousClass().equals(op)) {
-    	            	response.sendRedirect(response.encodeURL("classEdit.action?cid="+form.getPreviousId()));
-    	            	return null;
-    	            }
-
-					return DISPLAY_CLASS_DETAIL;
-            	} catch (Exception e) {
-            		tx.rollback(); throw e;
-            	}
-            }
-        }
-
-        Vector leadInstructors = new Vector();
-        if ("updatePref".equals(op)) {
-        	try {
-                List instrLead = form.getInstrLead();
-                List instructors = form.getInstructors();
-
-                for(int i=0; i<instructors.size(); i++) {
-                    String instrId = instructors.get(i).toString();
-                    if (Preference.BLANK_PREF_VALUE.equals(instrId)) continue;
-                    boolean lead = "on".equals(instrLead.get(i)) || "true".equals(instrLead.get(i));
-                    if (lead) leadInstructors.add((DepartmentalInstructorDAO.getInstance()).get(Long.valueOf(instrId)));
-                }
-        		op="init";
-        	} catch (NumberFormatException e) {}
-        }
-
-        if ("updateDatePattern".equals(op)) {        	
-			initPrefs(c, leadInstructors, true);
-			form.getDatePatternPrefs().clear();
-        	form.getDatePatternPrefLevels().clear();
-			DatePattern selectedDatePattern = (form.getDatePattern() < 0 ? c.getSchedulingSubpart().effectiveDatePattern() : DatePatternDAO.getInstance().get(form.getDatePattern()));
-			if (selectedDatePattern != null) {
-				for (DatePattern dp: selectedDatePattern.findChildren()) {
-					boolean found = false;
-					for (DatePatternPref dpp: (Set<DatePatternPref>)c.getPreferences(DatePatternPref.class)) {
-						if (dp.equals(dpp.getDatePattern())) {
-							form.addToDatePatternPrefs(dp.getUniqueId().toString(), dpp.getPrefLevel().getUniqueId().toString());
-							found = true;
-						}
-					}
-					if (!found)
-						for (DatePatternPref dpp: (Set<DatePatternPref>)c.getSchedulingSubpart().getPreferences(DatePatternPref.class)) {
-							if (dp.equals(dpp.getDatePattern())) {
-								form.addToDatePatternPrefs(dp.getUniqueId().toString(), dpp.getPrefLevel().getUniqueId().toString());
-								found = true;
-							}
-						}
-					if (!found)
-						form.addToDatePatternPrefs(dp.getUniqueId().toString(), PreferenceLevel.PREF_LEVEL_NEUTRAL);
-				}
-			}
+		if (MSG.actionUpdatePreferences().equals(op) || MSG.actionNextClass().equals(op) || MSG.actionPreviousClass().equals(op)) {
+			String result = handleUpdatePreferences(c, cdao, timeVertical);
+			if (result != null) return result;
 		}
-        
+
+		Vector leadInstructors = handleUpdatePref();
+
+		handleUpdateDatePatternIfNeeded(c, leadInstructors);
+
         // Initialize Preferences for initial load
-        form.setAvailableTimePatterns(TimePattern.findApplicable(
-        		sessionContext.getUser(),
-        		c.getSchedulingSubpart().getMinutesPerWk(),
-        		(form.getDatePattern() < 0 ? c.getSchedulingSubpart().effectiveDatePattern() : DatePatternDAO.getInstance().get(form.getDatePattern())),
-        		c.getSchedulingSubpart().getInstrOfferingConfig().getDurationModel(),
-        		true,
-        		c.getManagingDept()));
-		Set timePatterns = null;
-        if ("init".equals(op)) {
-        	initPrefs(c, leadInstructors, true);
-		    timePatterns = c.effectiveTimePatterns();
-		    
-		    DatePattern selectedDatePattern = c.effectiveDatePattern();
-			
-			if (selectedDatePattern != null) {
-				for (DatePattern dp: selectedDatePattern.findChildren()) {					
-					if (!form.getDatePatternPrefs().contains(
-							dp.getUniqueId().toString())) {
-						form.addToDatePatternPrefs(dp.getUniqueId().toString(), PreferenceLevel.PREF_LEVEL_NEUTRAL);
-					}
-				}
-			}
-		   
-        }
+		setupAvailableTimePatterns(c);
+
+		Set timePatterns = handleInitTimePatterns(c, leadInstructors);
 
 		// Process Preferences Action
 		processPrefAction();
 
         // Generate Time Pattern Grids
-		super.generateTimePatternGrids(c, 
-				c.getSchedulingSubpart().getMinutesPerWk(),
-        		c.getSchedulingSubpart().getInstrOfferingConfig().getDurationModel(),
-        		(form.getDatePattern() < 0 ? c.getSchedulingSubpart().effectiveDatePattern() : DatePatternDAO.getInstance().get(form.getDatePattern())),
-				timePatterns, op, timeVertical, true, leadInstructors);
+		generateGrids(c, timePatterns, timeVertical, leadInstructors);
 
-		// Instructors
-        setupInstructors(c);
-        setupChildren(c); // Date patterns allowed in the DDL for Date pattern preferences
-        LookupTables.setupDatePatterns(request, sessionContext.getUser(), MSG.dropDefaultDatePattern(), c.getSchedulingSubpart().effectiveDatePattern(), c.getManagingDept(), c.effectiveDatePattern());
-
-        LookupTables.setupRooms(request, c);		 // Rooms
-        LookupTables.setupBldgs(request, c);		 // Buildings
-        LookupTables.setupRoomFeatures(request, c); // Room Features
-        LookupTables.setupRoomGroups(request, c);   // Room Groups
+		setupFormLookups(c);
 
         form.setAllowHardPrefs(sessionContext.hasPermission(c, Right.CanUseHardRoomPrefs));
 
@@ -423,7 +240,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
         form.setManagingDeptLabel(managingDept.getManagingDeptLabel());
         form.setUnlimitedEnroll(c.getSchedulingSubpart().getInstrOfferingConfig().isUnlimitedEnrollment());
         form.setAccommodation(StudentAccomodation.toHtml(StudentAccomodation.getAccommodations(c)));
-        
+
         Class_ next = c.getNextClass(sessionContext, Right.ClassEdit);
         form.setNextId(next==null?null:next.getUniqueId().toString());
         Class_ previous = c.getPreviousClass(sessionContext, Right.ClassEdit);
@@ -432,40 +249,43 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
         form.setEnrollment(c.getEnrollment());
         form.setSnapshotLimit(c.getSnapshotLimit());
 
-        // Load from class only for initial load or reload
-        if ("init".equals(op)) {
-	        form.setExpectedCapacity(c.getExpectedCapacity());
-	        form.setDatePattern(c.getDatePattern()==null?Long.valueOf(-1):c.getDatePattern().getUniqueId());
-	        form.setDatePatternEditable(ApplicationProperty.WaitListCanChangeDatePattern.isTrue() || c.getEnrollment() == 0 || !c.getSchedulingSubpart().getInstrOfferingConfig().getInstructionalOffering().effectiveReScheduleNow());
-	        form.setNbrRooms(c.getNbrRooms());
-	        form.setSplitAttendance(c.isRoomsSplitAttendance());
-	        form.setNotes(c.getNotes());
-	        form.setManagingDept(c.getManagingDept().getUniqueId());
-		    form.setSchedulePrintNote(c.getSchedulePrintNote());
-		    form.setClassSuffix(c.getDivSecNumber());
-		    form.setMaxExpectedCapacity(c.getMaxExpectedCapacity());
-		    form.setRoomRatio(c.getRoomRatio());
-		    form.setLms(c.getLms() == null ? "" : c.getLms().getLabel());
-	        if (ApplicationProperty.CoursesFundingDepartmentsEnabled.isTrue()) {
-	        	form.setFundingDept(c.getEffectiveFundingDept().getLabel());
-	        } else {
-	        	form.setFundingDept("");
-	        }
-		    form.setEnabledForStudentScheduling(c.isEnabledForStudentScheduling());
-		    form.setDisplayInstructor(c.isDisplayInstructor());
-
-		    List instructors = new ArrayList(c.getClassInstructors());
-		    Collections.sort(instructors, new InstructorComparator(sessionContext));
-
-	        for(Iterator iter = instructors.iterator(); iter.hasNext(); ) {
-	            ClassInstructor classInstr = (ClassInstructor) iter.next();
-	            form.addToInstructors(classInstr);
-	        }
-
-	        if (instructors.isEmpty())
-	        	form.addToInstructors(null);
-        }
+		// Load from class only for initial load or reload
+		if ("init".equals(op))
+			doLoadInit(c);
     }
+
+	private void doLoadInit(Class_ c) {
+		form.setExpectedCapacity(c.getExpectedCapacity());
+		form.setDatePattern(c.getDatePattern()==null?Long.valueOf(-1):c.getDatePattern().getUniqueId());
+		form.setDatePatternEditable(ApplicationProperty.WaitListCanChangeDatePattern.isTrue() || c.getEnrollment() == 0 || !c.getSchedulingSubpart().getInstrOfferingConfig().getInstructionalOffering().effectiveReScheduleNow());
+		form.setNbrRooms(c.getNbrRooms());
+		form.setSplitAttendance(c.isRoomsSplitAttendance());
+		form.setNotes(c.getNotes());
+		form.setManagingDept(c.getManagingDept().getUniqueId());
+		form.setSchedulePrintNote(c.getSchedulePrintNote());
+		form.setClassSuffix(c.getDivSecNumber());
+		form.setMaxExpectedCapacity(c.getMaxExpectedCapacity());
+		form.setRoomRatio(c.getRoomRatio());
+		form.setLms(c.getLms() == null ? "" : c.getLms().getLabel());
+		if (ApplicationProperty.CoursesFundingDepartmentsEnabled.isTrue()) {
+			form.setFundingDept(c.getEffectiveFundingDept().getLabel());
+		} else {
+			form.setFundingDept("");
+		}
+		form.setEnabledForStudentScheduling(c.isEnabledForStudentScheduling());
+		form.setDisplayInstructor(c.isDisplayInstructor());
+
+		List instructors = new ArrayList(c.getClassInstructors());
+		Collections.sort(instructors, new InstructorComparator(sessionContext));
+
+		for(Iterator iter = instructors.iterator(); iter.hasNext(); ) {
+			ClassInstructor classInstr = (ClassInstructor) iter.next();
+			form.addToInstructors(classInstr);
+		}
+
+		if (instructors.isEmpty())
+			form.addToInstructors(null);
+	}
 
     /**
      * Update class data
@@ -484,13 +304,13 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
 	    //c.setClassSuffix(form.getClassSuffix());
 	    c.setMaxExpectedCapacity(form.getMaxExpectedCapacity());
 	    c.setRoomRatio(form.getRoomRatio());
-	    
+
 	    Boolean disb = form.getEnabledForStudentScheduling();
 	    c.setEnabledForStudentScheduling(disb==null ? Boolean.valueOf(false) : disb);
 
 	    Boolean di = form.getDisplayInstructor();
 	    c.setDisplayInstructor(di==null ? Boolean.valueOf(false) : di);
-	    
+
 	    boolean assignTeachingRequest = Department.isInstructorSchedulingCommitted(c.getControllingDept().getUniqueId());
 
         // Class all instructors
@@ -512,7 +332,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
             String resp = instrResponsibility.get(i).toString();
 
             DepartmentalInstructor deptInstr = DepartmentalInstructorDAO.getInstance().get(Long.valueOf(instrId));
-            
+
             ClassInstructor classInstr = null;
             for (Iterator<ClassInstructor> j = classInstrs.iterator(); j.hasNext();) {
             	ClassInstructor adept = j.next();
@@ -605,7 +425,242 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
             request.setAttribute(HASH_ATTR, HASH_INSTRUCTORS);
         }
     }
-    
+
+	private boolean handleLegacyRedirect() throws Exception {
+		if (ApplicationProperty.LegacyClassEdit.isFalse()) {
+			String url = "classEdit";
+			boolean first = true;
+			for (Enumeration<String> e = getRequest().getParameterNames(); e.hasMoreElements(); ) {
+				String param = e.nextElement();
+				url += (first ? "?" : "&") + param + "="
+						+ URLEncoder.encode(getRequest().getParameter(param), "utf-8");
+				first = false;
+			}
+			response.sendRedirect(url);
+			return true;
+		}
+		return false;
+	}
+
+	private String handleClearPreferences(Class_ c, Class_DAO cdao) throws Exception {
+		sessionContext.checkPermission(c, Right.ClassEditClearPreferences);
+		Set s = c.getPreferences();
+		doClear(s, Preference.Type.TIME, Preference.Type.ROOM, Preference.Type.ROOM_FEATURE,
+				Preference.Type.ROOM_GROUP, Preference.Type.BUILDING, Preference.Type.DATE);
+		c.setPreferences(s);
+		cdao.getSession().merge(c);
+		cdao.getSession().flush();
+		op = "init";
+		ChangeLog.addChange(null, sessionContext, c,
+				ChangeLog.Source.CLASS_EDIT, ChangeLog.Operation.CLEAR_PREF,
+				c.getSchedulingSubpart().getInstrOfferingConfig()
+						.getInstructionalOffering().getControllingCourseOffering().getSubjectArea(),
+				c.getManagingDept());
+		return DISPLAY_CLASS_DETAIL;
+	}
+
+	private String handleUpdatePreferences(Class_ c, Class_DAO cdao, boolean timeVertical) throws Exception {
+		form.validate(this);
+		if (hasFieldErrors()) return null;
+		org.hibernate.Session hibSession = cdao.getSession();
+		Transaction tx = hibSession.beginTransaction();
+		try {
+			Set s = c.getPreferences();
+			doClear(s, Preference.Type.TIME, Preference.Type.ROOM, Preference.Type.ROOM_FEATURE,
+					Preference.Type.ROOM_GROUP, Preference.Type.BUILDING, Preference.Type.DATE);
+			doUpdate(c, hibSession);
+			super.doUpdate(c, s, timeVertical,
+					Preference.Type.TIME, Preference.Type.ROOM, Preference.Type.ROOM_FEATURE,
+					Preference.Type.ROOM_GROUP, Preference.Type.BUILDING, Preference.Type.DATE);
+			hibSession.merge(c);
+			tx.commit();
+			String className = ApplicationProperty.ExternalActionClassEdit.value();
+			if (className != null && className.trim().length() > 0) {
+				ExternalClassEditAction editAction = (ExternalClassEditAction)
+						(Class.forName(className).getDeclaredConstructor().newInstance());
+				editAction.performExternalClassEditAction(c, hibSession);
+			}
+			if (MSG.actionNextClass().equals(op)) {
+				response.sendRedirect(response.encodeURL("classEdit.action?cid=" + form.getNextId()));
+				return null;
+			}
+			if (MSG.actionPreviousClass().equals(op)) {
+				response.sendRedirect(response.encodeURL("classEdit.action?cid=" + form.getPreviousId()));
+				return null;
+			}
+			return DISPLAY_CLASS_DETAIL;
+		} catch (Exception e) {
+			tx.rollback(); throw e;
+		}
+	}
+
+	private void handleUpdateDatePattern(Class_ c, Vector leadInstructors) {
+		initPrefs(c, leadInstructors, true);
+		form.getDatePatternPrefs().clear();
+		form.getDatePatternPrefLevels().clear();
+		DatePattern selectedDatePattern = (form.getDatePattern() < 0
+				? c.getSchedulingSubpart().effectiveDatePattern()
+				: DatePatternDAO.getInstance().get(form.getDatePattern()));
+		if (selectedDatePattern == null) return;
+		for (DatePattern dp : selectedDatePattern.findChildren()) {
+			addDatePatternPrefForChild(dp, c);
+		}
+	}
+
+	private void addDatePatternPrefForChild(DatePattern dp, Class_ c) {
+		boolean found = false;
+		for (DatePatternPref dpp : (Set<DatePatternPref>) c.getPreferences(DatePatternPref.class)) {
+			if (dp.equals(dpp.getDatePattern())) {
+				form.addToDatePatternPrefs(dp.getUniqueId().toString(), dpp.getPrefLevel().getUniqueId().toString());
+				found = true;
+			}
+		}
+		if (!found)
+			for (DatePatternPref dpp : (Set<DatePatternPref>) c.getSchedulingSubpart().getPreferences(DatePatternPref.class)) {
+				if (dp.equals(dpp.getDatePattern())) {
+					form.addToDatePatternPrefs(dp.getUniqueId().toString(), dpp.getPrefLevel().getUniqueId().toString());
+					found = true;
+				}
+			}
+		if (!found)
+			form.addToDatePatternPrefs(dp.getUniqueId().toString(), PreferenceLevel.PREF_LEVEL_NEUTRAL);
+	}
+
+	private boolean shouldReadClassIdFromForm(String op) {
+		return MSG.actionAddTimePreference().equals(op)
+				|| MSG.actionAddRoomPreference().equals(op)
+				|| MSG.actionAddBuildingPreference().equals(op)
+				|| MSG.actionAddRoomFeaturePreference().equals(op)
+				|| MSG.actionAddDistributionPreference().equals(op)
+				|| MSG.actionAddInstructor().equals(op)
+				|| MSG.actionUpdatePreferences().equals(op)
+				|| MSG.actionAddDatePatternPreference().equals(op)
+				|| MSG.actionAddAttributePreference().equals(op)
+				|| MSG.actionAddInstructorPreference().equals(op)
+				|| MSG.actionClearClassPreferences().equals(op)
+				|| MSG.actionRemoveBuildingPreference().equals(op)
+				|| MSG.actionRemoveDistributionPreference().equals(op)
+				|| MSG.actionRemoveRoomFeaturePreference().equals(op)
+				|| MSG.actionRemoveRoomGroupPreference().equals(op)
+				|| MSG.actionRemoveRoomPreference().equals(op)
+				|| MSG.actionRemoveDatePatternPreference().equals(op)
+				|| MSG.actionRemoveTimePattern().equals(op)
+				|| MSG.actionRemoveInstructor().equals(op)
+				|| MSG.actionRemoveAttributePreference().equals(op)
+				|| MSG.actionRemoveInstructorPreference().equals(op)
+				|| MSG.actionAddRoomGroupPreference().equals(op)
+				|| MSG.actionBackToDetail().equals(op)
+				|| MSG.actionNextClass().equals(op)
+				|| MSG.actionPreviousClass().equals(op)
+				|| "updateDatePattern".equals(op)
+				|| "updatePref".equals(op);
+	}
+
+	private Vector handleUpdatePref() {
+		Vector leadInstructors = new Vector();
+		if ("updatePref".equals(op)) {
+			try {
+				List instrLead = form.getInstrLead();
+				List instructors = form.getInstructors();
+				for (int i = 0; i < instructors.size(); i++) {
+					String instrId = instructors.get(i).toString();
+					if (Preference.BLANK_PREF_VALUE.equals(instrId)) continue;
+					boolean lead = "on".equals(instrLead.get(i)) || "true".equals(instrLead.get(i));
+					if (lead) leadInstructors.add((DepartmentalInstructorDAO.getInstance()).get(Long.valueOf(instrId)));
+				}
+				op = "init";
+			} catch (NumberFormatException e) {}
+		}
+		return leadInstructors;
+	}
+
+	private Set handleInitTimePatterns(Class_ c, Vector leadInstructors) {
+		Set timePatterns = null;
+		if ("init".equals(op)) {
+			initPrefs(c, leadInstructors, true);
+			timePatterns = c.effectiveTimePatterns();
+			DatePattern selectedDatePattern = c.effectiveDatePattern();
+			if (selectedDatePattern != null) {
+				for (DatePattern dp : selectedDatePattern.findChildren()) {
+					if (!form.getDatePatternPrefs().contains(dp.getUniqueId().toString())) {
+						form.addToDatePatternPrefs(dp.getUniqueId().toString(), PreferenceLevel.PREF_LEVEL_NEUTRAL);
+					}
+				}
+			}
+		}
+		return timePatterns;
+	}
+
+	private void handleInstructorOperations(Class_ c) {
+		if (MSG.actionAddInstructor().equals(op))
+			addInstructor();
+		if (MSG.actionRemoveInstructor().equals(op) && "instructor".equals(deleteType))
+			deleteInstructor();
+	}
+
+	private void setupAvailableTimePatterns(Class_ c) {
+		form.setAvailableTimePatterns(TimePattern.findApplicable(
+				sessionContext.getUser(),
+				c.getSchedulingSubpart().getMinutesPerWk(),
+				(form.getDatePattern() < 0
+						? c.getSchedulingSubpart().effectiveDatePattern()
+						: DatePatternDAO.getInstance().get(form.getDatePattern())),
+				c.getSchedulingSubpart().getInstrOfferingConfig().getDurationModel(),
+				true,
+				c.getManagingDept()));
+	}
+
+	private void setupFormLookups(Class_ c) throws Exception {
+		setupInstructors(c);
+		setupChildren(c);
+		LookupTables.setupDatePatterns(request, sessionContext.getUser(),
+				MSG.dropDefaultDatePattern(),
+				c.getSchedulingSubpart().effectiveDatePattern(),
+				c.getManagingDept(),
+				c.effectiveDatePattern());
+		LookupTables.setupRooms(request, c);
+		LookupTables.setupBldgs(request, c);
+		LookupTables.setupRoomFeatures(request, c);
+		LookupTables.setupRoomGroups(request, c);
+	}
+
+	private void initializeOp() {
+		if (op == null) op = form.getOp();
+		if (op2 != null && !op2.isEmpty()) op = op2;
+	}
+
+	private boolean isClassIdMissing() throws Exception {
+		if (classId == null || classId.trim().isEmpty()) {
+			if (BackTracker.doBack(request, response))
+				return true;
+			else
+				throw new Exception(MSG.errorClassInfoNotSupplied());
+		}
+		return false;
+	}
+
+	private void generateGrids(Class_ c, Set timePatterns, boolean timeVertical, Vector leadInstructors) throws Exception {
+		super.generateTimePatternGrids(c,
+				c.getSchedulingSubpart().getMinutesPerWk(),
+				c.getSchedulingSubpart().getInstrOfferingConfig().getDurationModel(),
+				(form.getDatePattern() < 0
+						? c.getSchedulingSubpart().effectiveDatePattern()
+						: DatePatternDAO.getInstance().get(form.getDatePattern())),
+				timePatterns, op, timeVertical, true, leadInstructors);
+	}
+
+	private void resetFormIfInit() {
+		if ("init".equals(op)) {
+			form.reset();
+		}
+	}
+
+	private void handleUpdateDatePatternIfNeeded(Class_ c, Vector leadInstructors) {
+		if ("updateDatePattern".equals(op)) {
+			handleUpdateDatePattern(c, leadInstructors);
+		}
+	}
+
     /**
      * This method is called to setup children of the selected date pattern of the class
      * or the selected date pattern of the scheduling subpart of the current class.
@@ -614,7 +669,7 @@ public class ClassEditAction extends PreferencesAction2<ClassEditForm> {
 		DatePattern selectedDatePattern = (form.getDatePattern() < 0 ? c.getSchedulingSubpart().effectiveDatePattern() : DatePatternDAO.getInstance().get(form.getDatePattern()));
 		if (selectedDatePattern != null) {
 			List<DatePattern> v =  selectedDatePattern.findChildren();
-			request.setAttribute(DatePattern.DATE_PATTERN_CHILDREN_LIST_ATTR, v);	
+			request.setAttribute(DatePattern.DATE_PATTERN_CHILDREN_LIST_ATTR, v);
 			form.sortDatePatternPrefs(form.getDatePatternPrefs(), form.getDatePatternPrefLevels(), v);
 		}
 	}


### PR DESCRIPTION
## Description
This pull request resolves issue CR-2 #7 and CR-2 #11 by refactoring high cognitive complexity methods and duplicated string literals in the codebase.
### Changes Made
* Refactored `execute()` method in `ClassEditAction.java` (complexity 105 → within limit) by extracting the following helper methods:
  `initializeOp()`, `shouldReadClassIdFromForm()`, `isClassIdMissing()`,
  `handleLegacyRedirect()`, `handleInstructorOperations()`, `handleClearPreferences()`,
  `resetFormIfInit()`, `handleUpdatePreferences()`, `handleUpdatePref()`,
  `handleUpdateDatePatternIfNeeded()`, `handleUpdateDatePattern()`,
  `addDatePatternPrefForChild()`, `handleInitTimePatterns()`,
  `setupAvailableTimePatterns()`, `setupFormLookups()`, `generateGrids()`
* Refactored `doLoad()` method in `ClassEditAction.java` (complexity 17 → within limit) by extracting `doLoadInit()`
* Extracted repeated `"displayClassDetail"` string into constant `DISPLAY_CLASS_DETAIL` in `ClassEditAction.java`
* Refactored `printTable()` method in `WebTable.java` (complexity 145 → within limit) by extracting the following helper methods:
  `appendNameRow()`, `resolveAsc()`, `appendHeaderRow()`, `appendHeaderCell()`,
  `buildHeaderText()`, `appendRowOpen()`, `appendAllRows()`,
  `appendRowCells()`, `appendDataCell()`
* Refactored `toCSVFile()` method in `WebTable.java` (complexity 29 → within limit) by extracting `appendCsvLines()`
* Extracted repeated `"right"` string into existing constant `ALIGN_RIGHT` in `WebTable.java`
* Extracted repeated `" colspan="` string into existing constant `COLSPAN` in `WebTable.java`
* Improved code readability and maintainability
* Reduced cognitive complexity and code duplication reported by static analysis tools
### Issue
Closes CR-2 
