### PR TITLE
Fix CR-1: Unclosed Resources and Null Safety Issues

### DIFF
--- a/JavaSource/org/unitime/commons/ant/CreateBaseModelFromXml.java
+++ b/JavaSource/org/unitime/commons/ant/CreateBaseModelFromXml.java
@@ -164,9 +164,11 @@ public class CreateBaseModelFromXml extends Task {
 				String name = setEl.attributeValue("name");
 				String column = setEl.element("key").attributeValue("column");
 				String clazz = fixType(setEl.element("many-to-many").attributeValue("class"), pkg);
-				clazz = clazz.substring(clazz.lastIndexOf('.')+1);
-				info("  set: " + clazz + "." + column + ":" + name);
-				iRelations.put(clazz + "." + column, name);
+				if (clazz != null){
+					clazz = clazz.substring(clazz.lastIndexOf('.')+1);
+					info("  set: " + clazz + "." + column + ":" + name);
+					iRelations.put(clazz + "." + column, name);
+				}
 			}
 		}
 		for (Iterator<Element> i=classEl.elementIterator("many-to-one");i.hasNext();) {
@@ -345,11 +347,12 @@ public class CreateBaseModelFromXml extends Task {
 		for (Iterator<Element> i = classEl.elementIterator("id"); i.hasNext();) {
 			Element el = i.next();
 			String type = fixType(el.attributeValue("type"), pkg);
-			if (type.indexOf('.')>=0) {
+			if (type != null && type.indexOf('.')>=0) {
 				imports.add(type);
 				type = type.substring(type.lastIndexOf('.')+1);
 			}
 			String name = fixName(el.attributeValue("name"));
+			if (name == null) continue;
 			String column = el.attributeValue("column").toLowerCase();
 			String attribute = name.substring(0,1).toLowerCase()+name.substring(1);
 			if ("default".equals(attribute)) attribute = "defaultValue";
@@ -1063,7 +1066,10 @@ public class CreateBaseModelFromXml extends Task {
 		
 		// BASE DAO class
 		File f = new File(fileFromPackage(outputFolder, pkg + ".base"), "Base" + className + "DAO.java");
-		if (f.exists()) f.delete();
+		if (f.exists()){
+			boolean deleted = f.delete();
+			if (!deleted) sLog.warn("Failed to delete file: " + f.getPath());
+		}
 		
 		// DAO class
 		File daoFile = new File(fileFromPackage(outputFolder, pkg+".dao"), className + "DAO.java");

--- a/JavaSource/org/unitime/commons/ant/WikiGet.java
+++ b/JavaSource/org/unitime/commons/ant/WikiGet.java
@@ -73,18 +73,19 @@ public class WikiGet extends Task {
     public boolean copy(URL url, File file) {
         try {
             System.out.print("  Get: "+url+" ");
-            InputStream is = url.openStream();
             file.getParentFile().mkdirs();
-            OutputStream os = new FileOutputStream(file);
-            byte[] buffer = new byte[16*1024];
-            int read = 0;
             long total = 0;
-            while ((read=is.read(buffer))>0) {
-                os.write(buffer,0,read);
-                total += read;
-                System.out.print(".");
-            }
-            os.flush();os.close();is.close();
+            try (InputStream is = url.openStream();
+                OutputStream os = new FileOutputStream(file)){
+                byte[] buffer = new byte[16*1024];
+                int read = 0;
+                while ((read=is.read(buffer))>0) {
+                    os.write(buffer,0,read);
+                    total += read;
+                    System.out.print(".");
+                }
+                os.flush();
+                }
             System.out.println(" "+total+" bytes read.");
             return true;
         } catch (IOException ex) {
@@ -93,20 +94,21 @@ public class WikiGet extends Task {
         }
         return false;
     }
-    
+
     public boolean copyAndParse(URL url, File file, Parser parser) {
         try {
             System.out.println("  Get: "+url);
-            BufferedReader is = new BufferedReader(new InputStreamReader(url.openStream()));
             file.getParentFile().mkdirs();
             if (file.getName().equalsIgnoreCase(".html")) file = new File(file.getParentFile(), "index.html");
-            PrintWriter pw = new PrintWriter(new FileWriter(file));
-            String line = null;
-            while ((line=is.readLine())!=null) {
-                line = parser.parse(line);
-                if (line!=null) pw.println(line);
+            try (BufferedReader is = new BufferedReader(new InputStreamReader(url.openStream()));
+                 PrintWriter pw = new PrintWriter(new FileWriter(file))) {
+                String line = null;
+                while ((line=is.readLine())!=null) {
+                    line = parser.parse(line);
+                    if (line!=null) pw.println(line);
+                }
+                pw.flush();
             }
-            pw.flush();pw.close();is.close();
             return true;
         } catch (Exception ex) {
             System.out.println();

--- a/JavaSource/org/unitime/commons/hibernate/util/DatabaseUpdate.java
+++ b/JavaSource/org/unitime/commons/hibernate/util/DatabaseUpdate.java
@@ -158,10 +158,10 @@ public abstract class DatabaseUpdate {
                         		hibSession.doWork(new Work() {
 									@Override
 									public void execute(Connection connection) throws SQLException {
-		                                Statement statement = connection.createStatement();
-		                                int lines = statement.executeUpdate(sql);
-		                                sLog.debug("  -- "+lines+" lines affected.");
-		                                statement.close();
+		                                try(Statement statement = connection.createStatement()){
+                                            int lines = statement.executeUpdate(sql);
+                                            sLog.debug("  -- "+lines+" lines affected.");
+                                        }
 									}
 								});
                         	} else throw e;

--- a/JavaSource/org/unitime/localization/impl/POHelper.java
+++ b/JavaSource/org/unitime/localization/impl/POHelper.java
@@ -118,13 +118,19 @@ public class POHelper extends ArrayList<POHelper.Block> {
 	public void readProperties(Bundle bundle, File sources, String locale) throws Exception {
 		Properties properties = new Properties();
 		File f = new File(sources, bundle.getClazz().getName().replace('.', '/') + "_" + locale + ".properties");
-		if (f.exists())
-			properties.load(new FileReader(f));
+		if (f.exists()) {
+			try (FileReader fr = new FileReader(f)) {
+				properties.load(fr);
+			}
+		}
 		
 		Properties enUK = new Properties();
 		f = new File(sources, bundle.getClazz().getName().replace('.', '/') + "_en_UK.properties");
-		if (f.exists())
-			enUK.load(new FileReader(f));
+		if (f.exists()) {
+			try (FileReader fr = new FileReader(f)) {
+				enUK.load(fr);
+			}
+		}
 		
 		if (PageNames.class.equals(bundle.getClazz())) {
 			for (String prop: new TreeSet<String>(iPageNames.keySet())) {


### PR DESCRIPTION
### Description
This pull request resolves CR-1 [#9](https://github.com/maroskayoussef/UniTime-Software-Maintenance-Project/issues/9) and [#10](https://github.com/maroskayoussef/UniTime-Software-Maintenance-Project/issues/10) by fixing unclosed resources and null safety issues in the codebase.

### Changes Made
- Wrapped `InputStream`, `FileOutputStream`, `BufferedReader`, and `PrintWriter` in try-with-resources in `WikiGet.java`
- Wrapped `FileReader` and `BufferedReader` instances in try-with-resources in `POHelper.java`
- Wrapped `Statement` in a try block to ensure proper closing in `DatabaseUpdate.java`
- Fixed null pointer issues and handled ignored return values in `CreateBaseModelFromXml.java`

### Issues
Closes #9
Closes #10