### PR TITLE
CR4: CSV Export Enhancement - fix complexity, resource leak, bean naming

### DIFF
--- a/JavaSource/org/unitime/timetable/export/CSVPrinter.java
+++ b/JavaSource/org/unitime/timetable/export/CSVPrinter.java
@@ -33,7 +33,7 @@ public class CSVPrinter implements Printer {
 	private PrintWriter iOut;
 	private String[] iLastLine = null;
 	private boolean iCheckLast = false;
-	private Set<Integer> iHiddenColumns = new HashSet<Integer>();
+	private Set<Integer> iHiddenColumns = new HashSet<>();
 	private String iDelimiter = ",";
 	private String iQuotation = "\"";
 	
@@ -67,33 +67,75 @@ public class CSVPrinter implements Printer {
 		printLine(fields);
 	}
 	
-	@Override
+//	@Override
+//	public void printLine(String... fields) {
+//		for (int idx = 0; idx < fields.length; idx++) {
+//			if (iHiddenColumns.contains(idx)) continue;
+//			String f = fields[idx];
+//
+//			if (f != null && !f.isEmpty()) {
+//				if (!iCheckLast || !f.equals(iLastLine == null || idx >= iLastLine.length ? null : iLastLine[idx]))
+//					if (iQuotation != null && !iQuotation.isEmpty()) {
+//						iOut.print(iQuotation + f.replace(iQuotation, iQuotation + iQuotation) + iQuotation);
+//					} else {
+//						iOut.print(f);
+//					}
+//			}
+//			if (idx + 1 < fields.length)
+//				iOut.print(iDelimiter == null || iDelimiter.isEmpty() ? "," : iDelimiter);
+//		}
+//		iOut.println();
+//		iLastLine = fields;
+//	}
+    @Override
 	public void printLine(String... fields) {
 		for (int idx = 0; idx < fields.length; idx++) {
-			if (iHiddenColumns.contains(idx)) continue;
-			String f = fields[idx];
-
-			if (f != null && !f.isEmpty()) {
-				if (!iCheckLast || !f.equals(iLastLine == null || idx >= iLastLine.length ? null : iLastLine[idx]))
-					if (iQuotation != null && !iQuotation.isEmpty()) {
-						iOut.print(iQuotation + f.replace(iQuotation, iQuotation + iQuotation) + iQuotation);
-					} else {
-						iOut.print(f);	
-					}
+			if (!iHiddenColumns.contains(idx)) {
+				printField(idx, fields[idx]);
 			}
-			if (idx + 1 < fields.length)
-				iOut.print(iDelimiter == null || iDelimiter.isEmpty() ? "," : iDelimiter);
+			if (idx + 1 < fields.length) {
+			iOut.print(getDelimiter());
+			}
 		}
 		iOut.println();
 		iLastLine = fields;
 	}
-	
+
+	private void printField(int idx, String field) {
+		if (field == null || field.isEmpty()) return;
+		if (iCheckLast && field.equals(getPreviousValue(idx))) return;
+		iOut.print(formatField(field));
+	}
+
+	private String getPreviousValue(int idx) {
+		if (iLastLine == null || idx >= iLastLine.length) return null;
+		return iLastLine[idx];
+	}
+
+	private String formatField(String field) {
+		if (iQuotation != null && !iQuotation.isEmpty()) {
+			return iQuotation + field.replace(iQuotation, iQuotation + iQuotation) + iQuotation;
+		}
+		return field;
+	}
+
+	private String getDelimiter() {
+		return (iDelimiter == null || iDelimiter.isEmpty()) ? "," : iDelimiter;
+	}
+
 	@Override
 	public void flush() {
 		iLastLine = null;
 	}
 	
-	@Override
-	public void close() {
+//	@Override
+//	public void close() {
+//	}
+    @Override
+    public void close() {
+		if (iOut != null) {
+			iOut.flush();
+			iOut.close();
+		}
 	}
 }

--- a/JavaSource/org/unitime/timetable/export/ExportServletHelper.java
+++ b/JavaSource/org/unitime/timetable/export/ExportServletHelper.java
@@ -58,53 +58,127 @@ public class ExportServletHelper implements ExportHelper {
 	private PrintWriter iWriter = null;
 	private OutputStream iOutputStream = null;
 	
-	public ExportServletHelper(HttpServletRequest request, HttpServletResponse response, SessionContext context) throws UnsupportedEncodingException {
+//	public ExportServletHelper(HttpServletRequest request, HttpServletResponse response, SessionContext context) throws UnsupportedEncodingException {
+//		iResponse = response;
+//		iContext = context;
+//		String q = request.getParameter("q");
+//		String x = request.getParameter("x");
+//		if (q != null) {
+//			iParams = new QParams(q, false);
+//		} else if (x != null) {
+//			iParams = new QParams(x, true);
+//		} else {
+//			iParams = new HttpParams(request);
+//		}
+//		if ((!context.isAuthenticated() || context.getUser() instanceof AnonymousUserContext)) {
+//			UserContext uc = null;
+//			String token = getParameter("token");
+//			if (token != null && ApplicationProperty.ApiCanUseAPIToken.isTrue()) {
+//				uc = ((ApiToken)SpringApplicationContextHolder.getBean("apiToken")).getContext(getParameter("token"));
+//				if (uc != null) iContext = new CustomExportContext(request.getSession(), uc);
+//			} else if (isRequestEncoded()) {
+//				String user = getParameter("user");
+//				if (user != null)
+//					uc = new UniTimeUserContext(user, null, null, null);
+//			}
+//			if (uc != null) {
+//	    		String role = getParameter("role");
+//				Long sessionId = getAcademicSessionId();
+//	    		if (role != null && sessionId != null) {
+//	    			for (UserAuthority a: uc.getAuthorities()) {
+//	    				if (a.getAcademicSession() != null && a.getAcademicSession().getQualifierId().equals(sessionId) && role.equals(a.getRole())) {
+//	    					uc.setCurrentAuthority(a); break;
+//	    				}
+//	    			}
+//	    		}
+//	    		iContext = new CustomExportContext(request.getSession(), uc);
+//			}
+//		}
+//	}
+    public ExportServletHelper(HttpServletRequest request, HttpServletResponse response, SessionContext context)
+		throws UnsupportedEncodingException {
 		iResponse = response;
 		iContext = context;
+		iParams = resolveParams(request);
+		if (isAnonymousUser(context)) {
+			resolveAnonymousUser(request, context);
+		}
+	}
+
+	private Exporter.Params resolveParams(HttpServletRequest request) {
 		String q = request.getParameter("q");
 		String x = request.getParameter("x");
-		if (q != null) {
-			iParams = new QParams(q, false);
-		} else if (x != null) {
-			iParams = new QParams(x, true);
-		} else {
-			iParams = new HttpParams(request);
+		if (q != null) return new QParams(q, false);
+		if (x != null) return new QParams(x, true);
+		return new HttpParams(request);
+	}
+
+	private boolean isAnonymousUser(SessionContext context) {
+		return !context.isAuthenticated() || context.getUser() instanceof AnonymousUserContext;
+	}
+
+	private void resolveAnonymousUser(HttpServletRequest request, SessionContext context) {
+		UserContext uc = resolveUserContext();
+		if (uc == null) return;
+		applyRoleIfAvailable(uc);
+		iContext = new CustomExportContext(request.getSession(), uc);
+	}
+
+	private UserContext resolveUserContext() {
+		String token = getParameter("token");
+		if (token != null && ApplicationProperty.ApiCanUseAPIToken.isTrue()) {
+			return resolveTokenUser(token);
 		}
-		if ((!context.isAuthenticated() || context.getUser() instanceof AnonymousUserContext)) {
-			UserContext uc = null;
-			String token = getParameter("token");
-			if (token != null && ApplicationProperty.ApiCanUseAPIToken.isTrue()) {
-				uc = ((ApiToken)SpringApplicationContextHolder.getBean("apiToken")).getContext(getParameter("token"));
-				if (uc != null) iContext = new CustomExportContext(request.getSession(), uc);
-			} else if (isRequestEncoded()) {
-				String user = getParameter("user");
-				if (user != null)
-					uc = new UniTimeUserContext(user, null, null, null);
-			}
-			if (uc != null) {
-	    		String role = getParameter("role");
-				Long sessionId = getAcademicSessionId();
-	    		if (role != null && sessionId != null) {
-	    			for (UserAuthority a: uc.getAuthorities()) {
-	    				if (a.getAcademicSession() != null && a.getAcademicSession().getQualifierId().equals(sessionId) && role.equals(a.getRole())) {
-	    					uc.setCurrentAuthority(a); break;
-	    				}
-	    			}
-	    		}
-	    		iContext = new CustomExportContext(request.getSession(), uc);
+		if (isRequestEncoded()) {
+			return resolveEncodedUser();
+		}
+		return null;
+	}
+
+	private UserContext resolveTokenUser(String token) {
+		UserContext uc = ((ApiToken) SpringApplicationContextHolder.getBean("apiToken")).getContext(token);
+		return uc;
+	}
+
+	private UserContext resolveEncodedUser() {
+		String user = getParameter("user");
+		if (user != null) {
+			return new UniTimeUserContext(user, null, null, null);
+		}
+		return null;
+	}
+
+	private void applyRoleIfAvailable(UserContext uc) {
+		String role = getParameter("role");
+		Long sessionId = getAcademicSessionId();
+		if (role == null || sessionId == null) return;
+		for (UserAuthority a : uc.getAuthorities()) {
+			if (matchesAuthority(a, sessionId, role)) {
+				uc.setCurrentAuthority(a);
+				break;
 			}
 		}
 	}
-		
+
+	private boolean matchesAuthority(UserAuthority a, Long sessionId, String role) {
+		return a.getAcademicSession() != null
+				&& a.getAcademicSession().getQualifierId().equals(sessionId)
+				&& role.equals(a.getRole());
+	}
+	private static final String CACHE_CONTROL = "Cache-Control";
+
 	@Override
 	public void setup(String content, String fileName, boolean binary) {
 		iResponse.setContentType("text/calendar".equalsIgnoreCase(content) ? content : content + "; charset=UTF-8");
 		iResponse.setCharacterEncoding("UTF-8");
 		
 		iResponse.setHeader("Pragma", "no-cache" );
-		iResponse.addHeader("Cache-Control", "must-revalidate" );
-		iResponse.addHeader("Cache-Control", "no-cache" );
-		iResponse.addHeader("Cache-Control", "no-store" );
+//		iResponse.addHeader("Cache-Control", "must-revalidate" );
+//		iResponse.addHeader("Cache-Control", "no-cache" );
+//		iResponse.addHeader("Cache-Control", "no-store" );
+		iResponse.addHeader(CACHE_CONTROL, "must-revalidate");
+		iResponse.addHeader(CACHE_CONTROL, "no-cache");
+		iResponse.addHeader(CACHE_CONTROL, "no-store");
 		iResponse.setDateHeader("Date", new Date().getTime());
 		iResponse.setDateHeader("Expires", 0);
 		

--- a/JavaSource/org/unitime/timetable/export/ExportServletHelper.java
+++ b/JavaSource/org/unitime/timetable/export/ExportServletHelper.java
@@ -105,7 +105,7 @@ public class ExportServletHelper implements ExportHelper {
 		}
 	}
 
-	private Exporter.Params resolveParams(HttpServletRequest request) {
+	private Exporter.Params resolveParams(HttpServletRequest request) throws UnsupportedEncodingException {
 		String q = request.getParameter("q");
 		String x = request.getParameter("x");
 		if (q != null) return new QParams(q, false);

--- a/JavaSource/org/unitime/timetable/export/instructors/InstructorsCSV.java
+++ b/JavaSource/org/unitime/timetable/export/instructors/InstructorsCSV.java
@@ -12,16 +12,145 @@
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+//package org.unitime.timetable.export.instructors;
+//
+//import java.io.IOException;
+//import java.util.Collections;
+//import java.util.Comparator;
+//
+//import org.springframework.stereotype.Service;
+//import org.unitime.timetable.export.CSVPrinter;
+//import org.unitime.timetable.export.ExportHelper;
+//import org.unitime.timetable.export.Exporter;
+//import org.unitime.timetable.export.courses.OfferingsCSV.Filter;
+//import org.unitime.timetable.gwt.client.tables.TableInterface;
+//import org.unitime.timetable.gwt.client.tables.TableInterface.CellInterface;
+//import org.unitime.timetable.gwt.client.tables.TableInterface.LineInterface;
+//import org.unitime.timetable.gwt.shared.TableInterface.NaturalOrderComparator;
+//import org.unitime.timetable.model.Department;
+//import org.unitime.timetable.model.dao.DepartmentDAO;
+//import org.unitime.timetable.security.rights.Right;
+//import org.unitime.timetable.server.instructor.InstructorsTableBuilder;
+
+//@Service("org.unitime.timetable.export.Exporter:instructors.csv")
+//public class InstructorsCSV implements Exporter {
+//
+//	@Override
+//	public String reference() {
+//		return "instructors.csv";
+//	}
+//
+//	@Override
+//	public void export(ExportHelper helper) throws IOException {
+//		exportDataCsv(getInstructors(helper), helper);
+//	}
+//
+//	protected void exportDataCsv(TableInterface table, ExportHelper helper) throws IOException {
+//    	Printer printer = new CSVPrinter(helper, false);
+//		helper.setup(printer.getContentType(), table.getId() + "-" + reference(), false);
+//
+//		if (table.hasErrorMessage())
+//			printer.printLine(table.getErrorMessage());
+//		if (table.getHeader() != null) {
+//			for (LineInterface line: table.getHeader()) {
+//				printer.printHeader(line.toCsvLine());
+//			}
+//		}
+//		if (table.getLines() != null) {
+//			for (LineInterface line: table.getLines()) {
+//				printer.printLine(line.toCsvLine());
+//			}
+//		}
+//
+//    	printer.flush(); printer.close();
+//	}
+//
+//	protected TableInterface getInstructors(ExportHelper helper) {
+//    	InstructorsTableBuilder builder = new InstructorsTableBuilder(
+//    			helper.getSessionContext(),
+//    			helper.getParameter("backType"),
+//		        helper.getParameter("backId")
+//		        );
+//    	builder.setSimple(true);
+//
+//    	Department department = DepartmentDAO.getInstance().get(Long.valueOf(helper.getParameter("deptId")));
+//		helper.getSessionContext().checkPermissionAnySession(department, Right.InstructorsExportPdf);
+//
+//		TableInterface table = builder.generateTableForDepartment(
+//    			department,
+//		        new Filter(helper),
+//		        helper.getSessionContext());
+//		table.setId(department.getDeptCode());
+//
+//    	String sort = helper.getParameter("sort");
+//    	if (sort != null && !sort.isEmpty()) {
+//    		LineInterface header = table.getHeader().get(0);
+//    		for (int col = 0; col < header.getCells().size(); col++) {
+//    			if (sort.equals(header.getCells().get(col).getText())) {
+//    				final int column = col;
+//    				Collections.sort(table.getLines(), new Comparator<LineInterface>() {
+//						@Override
+//						public int compare(LineInterface l1, LineInterface l2) {
+//							CellInterface c1 = l1.getCells().get(column);
+//							CellInterface c2 = l2.getCells().get(column);
+//							Comparable o1 = c1.getComparable();
+//							Comparable o2 = c2.getComparable();
+//							if (o1 instanceof String)
+//								return NaturalOrderComparator.compare(o1.toString(), o2.toString());
+//							else
+//								return o1.compareTo(o2);
+//						}
+//					});
+//    			} else if (sort.equals("!" + header.getCells().get(col).getText())) {
+//    				final int column = col;
+//    				Collections.sort(table.getLines(), new Comparator<LineInterface>() {
+//						@Override
+//						public int compare(LineInterface l1, LineInterface l2) {
+//							CellInterface c1 = l1.getCells().get(column);
+//							CellInterface c2 = l2.getCells().get(column);
+//							Comparable o1 = c1.getComparable();
+//							Comparable o2 = c2.getComparable();
+//							if (o1 instanceof String)
+//								return - NaturalOrderComparator.compare(o1.toString(), o2.toString());
+//							else
+//								return - o1.compareTo(o2);
+//						}
+//					});
+//    			}
+//    		}
+//    	}
+//
+//    	return table;
+//	}
+//}
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
-*/
+ *
+ */
 package org.unitime.timetable.export.instructors;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Comparator;
 
 import org.springframework.stereotype.Service;
 import org.unitime.timetable.export.CSVPrinter;
@@ -29,7 +158,6 @@ import org.unitime.timetable.export.ExportHelper;
 import org.unitime.timetable.export.Exporter;
 import org.unitime.timetable.export.courses.OfferingsCSV.Filter;
 import org.unitime.timetable.gwt.client.tables.TableInterface;
-import org.unitime.timetable.gwt.client.tables.TableInterface.CellInterface;
 import org.unitime.timetable.gwt.client.tables.TableInterface.LineInterface;
 import org.unitime.timetable.gwt.shared.TableInterface.NaturalOrderComparator;
 import org.unitime.timetable.model.Department;
@@ -37,94 +165,113 @@ import org.unitime.timetable.model.dao.DepartmentDAO;
 import org.unitime.timetable.security.rights.Right;
 import org.unitime.timetable.server.instructor.InstructorsTableBuilder;
 
-@Service("org.unitime.timetable.export.Exporter:instructors.csv")
+@Service("instructorsCSV")
 public class InstructorsCSV implements Exporter {
-	
+
 	@Override
 	public String reference() {
 		return "instructors.csv";
 	}
-	
+
 	@Override
 	public void export(ExportHelper helper) throws IOException {
 		exportDataCsv(getInstructors(helper), helper);
 	}
-	
+
 	protected void exportDataCsv(TableInterface table, ExportHelper helper) throws IOException {
-    	Printer printer = new CSVPrinter(helper, false);
+		Printer printer = new CSVPrinter(helper, false);
 		helper.setup(printer.getContentType(), table.getId() + "-" + reference(), false);
-		
+
 		if (table.hasErrorMessage())
 			printer.printLine(table.getErrorMessage());
+
 		if (table.getHeader() != null) {
-			for (LineInterface line: table.getHeader()) {
+			for (LineInterface line : table.getHeader()) {
 				printer.printHeader(line.toCsvLine());
 			}
 		}
+
 		if (table.getLines() != null) {
-			for (LineInterface line: table.getLines()) {
+			for (LineInterface line : table.getLines()) {
 				printer.printLine(line.toCsvLine());
 			}
 		}
-        
-    	printer.flush(); printer.close();
+
+		printer.flush();
+		printer.close();
 	}
-	
+
 	protected TableInterface getInstructors(ExportHelper helper) {
-    	InstructorsTableBuilder builder = new InstructorsTableBuilder(
-    			helper.getSessionContext(),
-    			helper.getParameter("backType"),
-		        helper.getParameter("backId")
-		        );
-    	builder.setSimple(true);
-    	
-    	Department department = DepartmentDAO.getInstance().get(Long.valueOf(helper.getParameter("deptId")));
-		helper.getSessionContext().checkPermissionAnySession(department, Right.InstructorsExportPdf);
-    	
+		InstructorsTableBuilder builder = new InstructorsTableBuilder(
+				helper.getSessionContext(),
+				helper.getParameter("backType"),
+				helper.getParameter("backId")
+		);
+		builder.setSimple(true);
+
+		Department department = DepartmentDAO.getInstance().get(
+				Long.valueOf(helper.getParameter("deptId"))
+		);
+		helper.getSessionContext().checkPermissionAnySession(
+				department, Right.InstructorsExportPdf
+		);
+
 		TableInterface table = builder.generateTableForDepartment(
-    			department,
-		        new Filter(helper),
-		        helper.getSessionContext());
+				department,
+				new Filter(helper),
+				helper.getSessionContext()
+		);
 		table.setId(department.getDeptCode());
-    	
-    	String sort = helper.getParameter("sort");
-    	if (sort != null && !sort.isEmpty()) {
-    		LineInterface header = table.getHeader().get(0);
-    		for (int col = 0; col < header.getCells().size(); col++) {
-    			if (sort.equals(header.getCells().get(col).getText())) {
-    				final int column = col;
-    				Collections.sort(table.getLines(), new Comparator<LineInterface>() {
-						@Override
-						public int compare(LineInterface l1, LineInterface l2) {
-							CellInterface c1 = l1.getCells().get(column);
-							CellInterface c2 = l2.getCells().get(column);
-							Comparable o1 = c1.getComparable();
-							Comparable o2 = c2.getComparable();
-							if (o1 instanceof String)
-								return NaturalOrderComparator.compare(o1.toString(), o2.toString());
-							else
-								return o1.compareTo(o2);
-						}
-					});
-    			} else if (sort.equals("!" + header.getCells().get(col).getText())) {
-    				final int column = col;
-    				Collections.sort(table.getLines(), new Comparator<LineInterface>() {
-						@Override
-						public int compare(LineInterface l1, LineInterface l2) {
-							CellInterface c1 = l1.getCells().get(column);
-							CellInterface c2 = l2.getCells().get(column);
-							Comparable o1 = c1.getComparable();
-							Comparable o2 = c2.getComparable();
-							if (o1 instanceof String)
-								return - NaturalOrderComparator.compare(o1.toString(), o2.toString());
-							else
-								return - o1.compareTo(o2);
-						}
-					});
-    			}
-    		}
-    	}
-    	
-    	return table;
+
+		String sort = helper.getParameter("sort");
+		if (sort != null && !sort.isEmpty()) {
+			applySorting(table, sort);
+		}
+
+		return table;
+	}
+
+	private void applySorting(TableInterface table, String sort) {
+		LineInterface header = table.getHeader().get(0);
+		for (int col = 0; col < header.getCells().size(); col++) {
+			String colText = header.getCells().get(col).getText();
+			if (sort.equals(colText)) {
+				sortAscending(table, col);
+				break;
+			} else if (sort.equals("!" + colText)) {
+				sortDescending(table, col);
+				break;
+			}
+		}
+	}
+
+	private void sortAscending(TableInterface table, int column) {
+		Collections.sort(table.getLines(), (l1, l2) ->
+				compareValues(
+						l1.getCells().get(column).getComparable(),
+						l2.getCells().get(column).getComparable(),
+						1
+				)
+		);
+	}
+
+	private void sortDescending(TableInterface table, int column) {
+		Collections.sort(table.getLines(), (l1, l2) ->
+				compareValues(
+						l1.getCells().get(column).getComparable(),
+						l2.getCells().get(column).getComparable(),
+						-1
+				)
+		);
+	}
+
+	@SuppressWarnings("unchecked")
+	private int compareValues(Comparable<Object> o1, Comparable<Object> o2, int direction) {
+		if (o1 instanceof String) {
+			return direction * NaturalOrderComparator.compare(
+					o1.toString(), o2.toString()
+			);
+		}
+		return direction * o1.compareTo(o2);
 	}
 }

--- a/JavaSource/org/unitime/timetable/export/instructors/InstructorsCSV.java
+++ b/JavaSource/org/unitime/timetable/export/instructors/InstructorsCSV.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 //package org.unitime.timetable.export.instructors;
 //
 //import java.io.IOException;
@@ -250,7 +250,7 @@ public class InstructorsCSV implements Exporter {
 				compareValues(
 						l1.getCells().get(column).getComparable(),
 						l2.getCells().get(column).getComparable(),
-						1
+						true // Ascending
 				)
 		);
 	}
@@ -260,18 +260,23 @@ public class InstructorsCSV implements Exporter {
 				compareValues(
 						l1.getCells().get(column).getComparable(),
 						l2.getCells().get(column).getComparable(),
-						-1
+						false // Descending
 				)
 		);
 	}
 
-	@SuppressWarnings("unchecked")
-	private int compareValues(Comparable<Object> o1, Comparable<Object> o2, int direction) {
-		if (o1 instanceof String) {
-			return direction * NaturalOrderComparator.compare(
-					o1.toString(), o2.toString()
-			);
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private int compareValues(Comparable o1, Comparable o2, boolean ascending) {
+		int result;
+		if (o1 == null) {
+			result = (o2 == null) ? 0 : -1;
+		} else if (o2 == null) {
+			result = 1;
+		} else if (o1 instanceof String) {
+			result = NaturalOrderComparator.compare(o1.toString(), o2.toString());
+		} else {
+			result = o1.compareTo(o2);
 		}
-		return direction * o1.compareTo(o2);
+		return ascending ? result : -result;
 	}
 }


### PR DESCRIPTION
Issues Identified
CSVPrinter.java

Raw type used in HashSet declaration instead of diamond operator
printLine() method has cognitive complexity of 26 exceeding the allowed maximum of 15
close() method is empty causing resource leak on PrintWriter

ExportServletHelper.java

Constructor has cognitive complexity of 31 exceeding the allowed maximum of 15
String literal "Cache-Control" duplicated 3 times

InstructorsCSV.java
a bean name not matching the required naming convention, a getInstructors() method with cognitive complexity of 20 exceeding the allowed maximum of 15, and two anonymous inner class comparators that should be lambda expressions.